### PR TITLE
feat: add GitHub Actions CI for portable release builds

### DIFF
--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -85,8 +85,8 @@ jobs:
           .\python\python.exe -m pip install -r backend\requirements.txt --no-warn-script-location
           .\python\python.exe -m pip cache purge
 
-      - name: Copy config example
-        run: copy cs2-insight.config.example.json cs2-insight.config.json
+      - name: Copy config example (template only, first run auto-creates real config)
+        run: echo "cs2-insight.config.example.json 作为模板参考，首次启动应用会自动生成 cs2-insight.config.json"
 
       - name: Smoke test
         run: .\python\python.exe -c "import fastapi; print('Smoke test passed')"
@@ -151,7 +151,7 @@ jobs:
           echo "pkg=$pkg" >> $env:GITHUB_OUTPUT
 
       - name: Package ZIP
-        run: 7z a "${{ steps.name.outputs.pkg }}.zip" backend python web cs2-insight.config.json 启动.bat 修复依赖.bat
+        run: 7z a "${{ steps.name.outputs.pkg }}.zip" backend python web cs2-insight.config.example.json 启动.bat 修复依赖.bat
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -101,6 +101,7 @@ jobs:
           echo.
           echo [注意] 此版本由 CI 自动构建，仅供测试，可能有未预期的 bug。
           echo.
+          set "PYTHONPATH=%ROOT%backend"
           "%ROOT%python\python.exe" -m app.run_server
           pause
           "@ | Set-Content -Encoding utf8 启动.bat

--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -151,7 +151,7 @@ jobs:
           echo "pkg=$pkg" >> $env:GITHUB_OUTPUT
 
       - name: Package ZIP
-        run: 7z a "${{ steps.name.outputs.pkg }}.zip" backend python web cs2-insight.config.example.json 启动.bat 修复依赖.bat
+        run: 7z a "${{ steps.name.outputs.pkg }}.zip" backend python web pov cs2-insight.config.example.json 启动.bat 修复依赖.bat
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -86,7 +86,7 @@ jobs:
           .\python\python.exe -m pip cache purge
 
       - name: Copy config example (template only, first run auto-creates real config)
-        run: echo "cs2-insight.config.example.json 作为模板参考，首次启动应用会自动生成 cs2-insight.config.json"
+        run: echo "data/cs2-insight.config.example.json 作为模板参考，首次启动应用会自动生成 cs2-insight.config.json"
 
       - name: Smoke test
         run: .\python\python.exe -c "import fastapi; print('Smoke test passed')"
@@ -151,7 +151,7 @@ jobs:
           echo "pkg=$pkg" >> $env:GITHUB_OUTPUT
 
       - name: Package ZIP
-        run: 7z a "${{ steps.name.outputs.pkg }}.zip" backend python web pov cs2-insight.config.example.json 启动.bat 修复依赖.bat
+        run: 7z a "${{ steps.name.outputs.pkg }}.zip" backend python web pov data/cs2-insight.config.example.json 启动.bat 修复依赖.bat
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -11,7 +11,7 @@ on:
         default: ''
 
 env:
-  PYTHON_VERSION: '3.12.12'
+  PYTHON_VERSION: '3.12.10'
 
 jobs:
   build:

--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -1,0 +1,146 @@
+# Dev / test build — manual trigger only, artifact download (no release).
+# 开发测试用：手动触发 → 构建便携包 → 在 Actions 页面下载 ZIP。
+name: Build Dev Package
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Branch / tag / commit to build (留空使用默认分支)'
+        required: false
+        default: ''
+
+env:
+  PYTHON_VERSION: '3.12.12'
+
+jobs:
+  build:
+    runs-on: windows-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Build frontend
+        run: |
+          cd frontend
+          npm ci
+          npm run build
+          cd ..
+          if (!(Test-Path frontend\dist)) { Write-Error "前端构建产物未生成"; exit 1 }
+          if (Test-Path web) { Remove-Item web -Recurse -Force }
+          move frontend\dist web
+
+      - name: Download Python embeddable
+        run: |
+          curl -L -o python-embed.zip "https://www.python.org/ftp/python/$env:PYTHON_VERSION/python-$env:PYTHON_VERSION-embed-amd64.zip"
+          mkdir python
+          tar -xf python-embed.zip -C python
+          del python-embed.zip
+
+      - name: Enable site-packages in embedded Python
+        run: |
+          cd python
+          $pth = Get-ChildItem -Filter "python*._pth" | Select-Object -First 1
+          if ($pth) {
+            (Get-Content $pth.Name) -replace '^\s*#import site', 'import site' | Set-Content -Encoding utf8 $pth.Name
+          }
+          cd ..
+
+      - name: Install pip into embedded Python
+        # 注意：直接从 bootstrap.pypa.io 下载脚本执行，存在供应链风险。
+        # 当前项目规模下可接受，若需加固可改为校验预置哈希或改用 ensurepip。
+        run: |
+          curl -L -o get-pip.py https://bootstrap.pypa.io/get-pip.py
+          .\python\python.exe get-pip.py --no-warn-script-location
+          del get-pip.py
+
+      - name: Install backend dependencies
+        run: |
+          .\python\python.exe -m pip install -r backend\requirements.txt --no-warn-script-location
+          .\python\python.exe -m pip cache purge
+
+      - name: Copy config example
+        run: copy cs2-insight.config.example.json cs2-insight.config.json
+
+      - name: Smoke test
+        run: .\python\python.exe -c "import fastapi; print('Smoke test passed')"
+
+      - name: Create launcher scripts (dev)
+        run: |
+          @"
+          @echo off
+          chcp 65001 >nul
+          setlocal
+          set "ROOT=%~dp0"
+          if not exist "%ROOT%python\python.exe" (
+            echo [错误] 缺少 python\python.exe，请重新解压完整发行包。
+            pause
+            exit /b 1
+          )
+          cd /d "%ROOT%backend" 2>nul
+          if errorlevel 1 (
+            echo [错误] 找不到 backend 目录。
+            pause
+            exit /b 1
+          )
+          echo.
+          echo CS2 Insight Agent [测试版]
+          if not defined CS2_INSIGHT_PORT set "CS2_INSIGHT_PORT=8000"
+          echo Backend: http://127.0.0.1:%CS2_INSIGHT_PORT%
+          echo.
+          echo [注意] 此版本由 CI 自动构建，仅供测试，可能有未预期的 bug。
+          echo.
+          "%ROOT%python\python.exe" -m app.run_server
+          pause
+          "@ | Set-Content -Encoding utf8 启动.bat
+
+          @"
+          @echo off
+          chcp 65001 >nul
+          setlocal
+          set "ROOT=%~dp0"
+          if not exist "%ROOT%python\python.exe" (
+            echo [错误] 缺少 python\python.exe
+            pause
+            exit /b 1
+          )
+          if not exist "%ROOT%backend\requirements.txt" (
+            echo [错误] 缺少 backend\requirements.txt
+            pause
+            exit /b 1
+          )
+          echo 正在安装/修复 Python 依赖...
+          "%ROOT%python\python.exe" -m pip install --no-warn-script-location -r "%ROOT%backend\requirements.txt"
+          echo.
+          echo 完成。
+          pause
+          "@ | Set-Content -Encoding utf8 修复依赖.bat
+
+      - name: Set package name
+        id: name
+        run: |
+          $ts = (Get-Date -Format "yyyyMMdd-HHmmss")
+          $sha = "${{ github.sha }}".Substring(0, 7)
+          $pkg = "CS2-Insight-Agent-dev-${ts}-${sha}"
+          echo "pkg=$pkg" >> $env:GITHUB_OUTPUT
+
+      - name: Package ZIP
+        run: 7z a "${{ steps.name.outputs.pkg }}.zip" backend python web cs2-insight.config.json 启动.bat 修复依赖.bat
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.name.outputs.pkg }}
+          path: "${{ steps.name.outputs.pkg }}.zip"
+          retention-days: 90

--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -48,12 +48,27 @@ jobs:
           tar -xf python-embed.zip -C python
           del python-embed.zip
 
-      - name: Enable site-packages in embedded Python
+      - name: Configure embedded Python (site-packages + backend path)
+        # 嵌入式 Python 的 ._pth 文件控制 sys.path，且会忽略 PYTHONPATH 环境变量。
+        # 必须在此文件中显式添加 backend 路径，否则 python -m app.run_server 找不到模块。
         run: |
           cd python
           $pth = Get-ChildItem -Filter "python*._pth" | Select-Object -First 1
           if ($pth) {
-            (Get-Content $pth.Name) -replace '^\s*#import site', 'import site' | Set-Content -Encoding utf8 $pth.Name
+            $lines = Get-Content $pth.Name
+            $out = @()
+            foreach ($line in $lines) {
+              if ($line -match '^\s*#import site') {
+                $out += '..\backend'
+                $out += 'import site'
+              } elseif ($line -match '^\s*import site') {
+                $out += '..\backend'
+                $out += $line
+              } else {
+                $out += $line
+              }
+            }
+            $out | Set-Content -Encoding utf8 $pth.Name
           }
           cd ..
 
@@ -101,7 +116,6 @@ jobs:
           echo.
           echo [注意] 此版本由 CI 自动构建，仅供测试，可能有未预期的 bug。
           echo.
-          set "PYTHONPATH=%ROOT%backend"
           "%ROOT%python\python.exe" -m app.run_server
           pause
           "@ | Set-Content -Encoding utf8 启动.bat

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -147,7 +147,7 @@ jobs:
       - name: Set package name
         id: name
         run: |
-          if ("${{ github.ref_type }}" -eq "tag" -and "${{ github.event_name }}" -eq "push") {
+          if ("${{ github.ref_type }}" -eq "tag") {
             $ver = "${{ github.ref_name }}" -replace '^V', ''
             $pkg = "CS2-Insight-Agent-V${ver}"
           } else {

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -54,12 +54,25 @@ jobs:
           tar -xf python-embed.zip -C python
           del python-embed.zip
 
-      - name: Enable site-packages in embedded Python
+      - name: Configure embedded Python (site-packages + backend path)
         run: |
           cd python
           $pth = Get-ChildItem -Filter "python*._pth" | Select-Object -First 1
           if ($pth) {
-            (Get-Content $pth.Name) -replace '^\s*#import site', 'import site' | Set-Content -Encoding utf8 $pth.Name
+            $lines = Get-Content $pth.Name
+            $out = @()
+            foreach ($line in $lines) {
+              if ($line -match '^\s*#import site') {
+                $out += '..\backend'
+                $out += 'import site'
+              } elseif ($line -match '^\s*import site') {
+                $out += '..\backend'
+                $out += $line
+              } else {
+                $out += $line
+              }
+            }
+            $out | Set-Content -Encoding utf8 $pth.Name
           }
           cd ..
 
@@ -105,7 +118,6 @@ jobs:
           if not defined CS2_INSIGHT_PORT set "CS2_INSIGHT_PORT=8000"
           echo Backend: http://127.0.0.1:%CS2_INSIGHT_PORT%
           echo.
-          set "PYTHONPATH=%ROOT%backend"
           "%ROOT%python\python.exe" -m app.run_server
           pause
           "@ | Set-Content -Encoding utf8 启动.bat

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -15,7 +15,7 @@ on:
         default: ''
 
 env:
-  PYTHON_VERSION: '3.12.12'
+  PYTHON_VERSION: '3.12.10'
 
 jobs:
   build:

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,0 +1,164 @@
+# Release build — tag trigger auto-publishes to GitHub Release; manual trigger
+# uploads as artifact only to avoid polluting the tag / release list.
+# 正式发布：打 V* tag → 自动构建并发布到 Release。
+# 手动触发：仅上传 artifact，不创建 Release 或标签。
+name: Build Release Package
+
+on:
+  push:
+    tags: ['V*']
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Branch / tag / commit to build'
+        required: false
+        default: ''
+
+env:
+  PYTHON_VERSION: '3.12.12'
+
+jobs:
+  build:
+    runs-on: windows-latest
+    timeout-minutes: 30
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Build frontend
+        run: |
+          cd frontend
+          npm ci
+          npm run build
+          cd ..
+          if (!(Test-Path frontend\dist)) { Write-Error "前端构建产物未生成"; exit 1 }
+          if (Test-Path web) { Remove-Item web -Recurse -Force }
+          move frontend\dist web
+
+      - name: Download Python embeddable
+        run: |
+          curl -L -o python-embed.zip "https://www.python.org/ftp/python/$env:PYTHON_VERSION/python-$env:PYTHON_VERSION-embed-amd64.zip"
+          mkdir python
+          tar -xf python-embed.zip -C python
+          del python-embed.zip
+
+      - name: Enable site-packages in embedded Python
+        run: |
+          cd python
+          $pth = Get-ChildItem -Filter "python*._pth" | Select-Object -First 1
+          if ($pth) {
+            (Get-Content $pth.Name) -replace '^\s*#import site', 'import site' | Set-Content -Encoding utf8 $pth.Name
+          }
+          cd ..
+
+      - name: Install pip into embedded Python
+        # 注意：直接从 bootstrap.pypa.io 下载脚本执行，存在供应链风险。
+        # 当前项目规模下可接受，若需加固可改为校验预置哈希或改用 ensurepip。
+        run: |
+          curl -L -o get-pip.py https://bootstrap.pypa.io/get-pip.py
+          .\python\python.exe get-pip.py --no-warn-script-location
+          del get-pip.py
+
+      - name: Install backend dependencies
+        run: |
+          .\python\python.exe -m pip install -r backend\requirements.txt --no-warn-script-location
+          .\python\python.exe -m pip cache purge
+
+      - name: Copy config example
+        run: copy cs2-insight.config.example.json cs2-insight.config.json
+
+      - name: Smoke test
+        run: .\python\python.exe -c "import fastapi; print('Smoke test passed')"
+
+      - name: Create launcher scripts
+        run: |
+          @"
+          @echo off
+          chcp 65001 >nul
+          setlocal
+          set "ROOT=%~dp0"
+          if not exist "%ROOT%python\python.exe" (
+            echo [错误] 缺少 python\python.exe，请重新解压完整发行包。
+            pause
+            exit /b 1
+          )
+          cd /d "%ROOT%backend" 2>nul
+          if errorlevel 1 (
+            echo [错误] 找不到 backend 目录。
+            pause
+            exit /b 1
+          )
+          echo.
+          echo CS2 Insight Agent
+          if not defined CS2_INSIGHT_PORT set "CS2_INSIGHT_PORT=8000"
+          echo Backend: http://127.0.0.1:%CS2_INSIGHT_PORT%
+          echo.
+          "%ROOT%python\python.exe" -m app.run_server
+          pause
+          "@ | Set-Content -Encoding utf8 启动.bat
+
+          @"
+          @echo off
+          chcp 65001 >nul
+          setlocal
+          set "ROOT=%~dp0"
+          if not exist "%ROOT%python\python.exe" (
+            echo [错误] 缺少 python\python.exe
+            pause
+            exit /b 1
+          )
+          if not exist "%ROOT%backend\requirements.txt" (
+            echo [错误] 缺少 backend\requirements.txt
+            pause
+            exit /b 1
+          )
+          echo 正在安装/修复 Python 依赖...
+          "%ROOT%python\python.exe" -m pip install --no-warn-script-location -r "%ROOT%backend\requirements.txt"
+          echo.
+          echo 完成。
+          pause
+          "@ | Set-Content -Encoding utf8 修复依赖.bat
+
+      - name: Set package name
+        id: name
+        run: |
+          if ("${{ github.ref_type }}" -eq "tag" -and "${{ github.event_name }}" -eq "push") {
+            $ver = "${{ github.ref_name }}" -replace '^V', ''
+            $pkg = "CS2-Insight-Agent-V${ver}"
+          } else {
+            $ts = (Get-Date -Format "yyyyMMdd-HHmmss")
+            $sha = "${{ github.sha }}".Substring(0, 7)
+            $pkg = "CS2-Insight-Agent-dev-${ts}-${sha}"
+          }
+          echo "pkg=$pkg" >> $env:GITHUB_OUTPUT
+
+      - name: Package ZIP
+        run: 7z a "${{ steps.name.outputs.pkg }}.zip" backend python web cs2-insight.config.json 启动.bat 修复依赖.bat
+
+      - name: Upload to Release
+        if: github.ref_type == 'tag' && github.event_name == 'push'
+        uses: softprops/action-gh-release@v2
+        with:
+          name: ${{ steps.name.outputs.pkg }}
+          files: "${{ steps.name.outputs.pkg }}.zip"
+          generate_release_notes: true
+
+      - name: Upload artifact (manual trigger only)
+        if: github.ref_type != 'tag' || github.event_name != 'push'
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.name.outputs.pkg }}
+          path: "${{ steps.name.outputs.pkg }}.zip"
+          retention-days: 30

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -158,7 +158,7 @@ jobs:
           echo "pkg=$pkg" >> $env:GITHUB_OUTPUT
 
       - name: Package ZIP
-        run: 7z a "${{ steps.name.outputs.pkg }}.zip" backend python web cs2-insight.config.example.json 启动.bat 修复依赖.bat
+        run: 7z a "${{ steps.name.outputs.pkg }}.zip" backend python web pov cs2-insight.config.example.json 启动.bat 修复依赖.bat
 
       - name: Upload to Release
         if: github.ref_type == 'tag' && github.event_name == 'push'

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -90,7 +90,7 @@ jobs:
           .\python\python.exe -m pip cache purge
 
       - name: Copy config example (template only, first run auto-creates real config)
-        run: echo "cs2-insight.config.example.json 作为模板参考，首次启动应用会自动生成 cs2-insight.config.json"
+        run: echo "data/cs2-insight.config.example.json 作为模板参考，首次启动应用会自动生成 cs2-insight.config.json"
 
       - name: Smoke test
         run: .\python\python.exe -c "import fastapi; print('Smoke test passed')"
@@ -158,7 +158,7 @@ jobs:
           echo "pkg=$pkg" >> $env:GITHUB_OUTPUT
 
       - name: Package ZIP
-        run: 7z a "${{ steps.name.outputs.pkg }}.zip" backend python web pov cs2-insight.config.example.json 启动.bat 修复依赖.bat
+        run: 7z a "${{ steps.name.outputs.pkg }}.zip" backend python web pov data/cs2-insight.config.example.json 启动.bat 修复依赖.bat
 
       - name: Upload to Release
         if: github.ref_type == 'tag' && github.event_name == 'push'

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -89,8 +89,8 @@ jobs:
           .\python\python.exe -m pip install -r backend\requirements.txt --no-warn-script-location
           .\python\python.exe -m pip cache purge
 
-      - name: Copy config example
-        run: copy cs2-insight.config.example.json cs2-insight.config.json
+      - name: Copy config example (template only, first run auto-creates real config)
+        run: echo "cs2-insight.config.example.json 作为模板参考，首次启动应用会自动生成 cs2-insight.config.json"
 
       - name: Smoke test
         run: .\python\python.exe -c "import fastapi; print('Smoke test passed')"
@@ -158,7 +158,7 @@ jobs:
           echo "pkg=$pkg" >> $env:GITHUB_OUTPUT
 
       - name: Package ZIP
-        run: 7z a "${{ steps.name.outputs.pkg }}.zip" backend python web cs2-insight.config.json 启动.bat 修复依赖.bat
+        run: 7z a "${{ steps.name.outputs.pkg }}.zip" backend python web cs2-insight.config.example.json 启动.bat 修复依赖.bat
 
       - name: Upload to Release
         if: github.ref_type == 'tag' && github.event_name == 'push'

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -105,6 +105,7 @@ jobs:
           if not defined CS2_INSIGHT_PORT set "CS2_INSIGHT_PORT=8000"
           echo Backend: http://127.0.0.1:%CS2_INSIGHT_PORT%
           echo.
+          set "PYTHONPATH=%ROOT%backend"
           "%ROOT%python\python.exe" -m app.run_server
           pause
           "@ | Set-Content -Encoding utf8 启动.bat


### PR DESCRIPTION
## 概述

新增两个 GitHub Actions 工作流，自动化 Windows 便携包的构建流程，替代当前手动打包发布的方式。

## 两个工作流

| | Build Dev Package | Build Release Package |
|---|---|---|
| 触发 | 手动 `workflow_dispatch` | 打 `V*` tag 自动 + 手动 |
| 产物 | Artifact（90天） | GitHub Release |
| 启动.bat | `[测试版]` 标注 | 正式版 |
| 包名 | `CS2-Insight-Agent-dev-{时间戳}-{sha}` | `CS2-Insight-Agent-V{版本号}` |

## 构建流程

1. **Checkout** → 构建前端（`npm run build` → `web/`）
2. 下载 **Python 3.12.10 embeddable**，配置 `._pth`（启用 site-packages + 添加 backend 路径）
3. 安装 pip + 后端依赖 → 清理缓存
4. **冒烟测试**：`import fastapi` 验证依赖加载
5. 生成 `启动.bat` / `修复依赖.bat`（UTF-8 + chcp 65001，中文不乱码）
6. 打包 ZIP：`backend/` `python/` `web/` `pov/` + 配置模板 + launcher

## ZIP 结构

```
CS2-Insight-Agent-V{ver}.zip
├── backend/       # Python 后端源码
├── python/        # 嵌入式 Python 3.12.10 + 全部依赖
├── web/           # 前端构建产物
├── pov/           # POV HUD mod 文件
├── cs2-insight.config.example.json  # 配置模板（首次启动自动生成实际 config）
├── 启动.bat
└── 修复依赖.bat
```

## 测试情况

- ✅ **Dev 工作流**：已在 Windows 上完成测试，解压运行正常（后端启动、前端访问均通过）
- ⚠️ **Release 工作流**：构建逻辑与 Dev 完全相同（仅上传目标不同），尚未独立测试

## 注意事项

- Python 版本固定 3.12.10（3.12.11+ 无 Windows 二进制包）
- 手动触发 Release 工作流**不会创建 Release/标签**（已做 `ref_type + event_name` 双重门控）
- 首次运行应用会自动从默认配置生成 `cs2-insight.config.json`，覆盖安装不会冲掉已有配置
- `get-pip.py` 存在供应链风险（已注释说明）

## 待作者处理

- 文档：Release ZIP 目前未包含 README / PLAYER_GUIDE 等文档。仓库中已有 `README.md`、`PLAYER_GUIDE.md`、`LICENSE`、`THIRD_PARTY_LICENSES.md`，请自行决定哪些需要打包进去及格式（是否需要转 txt）

🤖 Generated with [Claude Code](https://claude.com/claude-code)