### PR TITLE
feat: 前端布局优化、交互修复与拖拽问题修复

### DIFF
--- a/backend/app/env_utils.py
+++ b/backend/app/env_utils.py
@@ -122,7 +122,7 @@ class OBSConfig(BaseModel):
 
 class LLMConfig(BaseModel):
     provider: str = "deepseek"
-    model: str = "deepseek-chat"
+    model: str = "deepseek-v4-flash"
     api_key: str = ""
     base_url: Optional[str] = None
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -12,6 +12,7 @@ import MatchSwitcher from "./components/MatchSwitcher";
 import LibraryLoadModeModal from "./components/LibraryLoadModeModal";
 import RecordingQueueDrawer from "./components/RecordingQueueDrawer";
 import CommonParamsModal from "./components/CommonParamsModal";
+import ToastContainer from "./components/Toast";
 import { useRecordingQueue, stripGlobalPacingMetaKeys } from "./stores/recordingQueueStore";
 import { ensureClientClipUidsOnClips, stripClientClipUid } from "./utils/clipClientUid";
 import {
@@ -248,6 +249,9 @@ export default function App() {
     currentMatchIndexRef.current = currentMatchIndex;
   }, [currentMatchIndex]);
 
+  // 按 matchIndex → playerName 缓存选中状态，避免切换 Tab 丢失选择
+  const selectionsByMatchRef = useRef({});
+
   /** 每场 Demo 独立的多选玩家列表（索引 -> string[]） */
   const [selectedPlayers, setSelectedPlayers] = useState({});
   /** 每场「回合合集」勾选：空 → 请求里发 null（整局合规非赛后）；非空 → 只解析所选回合 */
@@ -263,6 +267,16 @@ export default function App() {
   /** 按场次索引的后台解析（与上传时的全局 parsing 区分，便于切换场次） */
   const [parsingByIndex, setParsingByIndex] = useState({});
   const [progressText, setProgressText] = useState("");
+
+  // ── Toast 通知系统 ──
+  const [toasts, setToasts] = useState([]);
+  const addToast = useCallback((message, type = "info", duration = 4000) => {
+    const id = Date.now() + Math.random();
+    setToasts((prev) => [...prev, { id, message, type, duration }]);
+  }, []);
+  const dismissToast = useCallback((id) => {
+    setToasts((prev) => prev.filter((t) => t.id !== id));
+  }, []);
   const [batchRecording, setBatchRecording] = useState(false);
   const [recordingBlockedMessage, setRecordingBlockedMessage] = useState("");
   const [recordWarmupOpen, setRecordWarmupOpen] = useState(false);
@@ -412,9 +426,20 @@ export default function App() {
     });
   }, [queuedClientClipUidsForCurrentDemo]);
 
-  // 切换玩家 Tab 时清空选中状态
+  // 切换玩家 Tab 时保存/恢复选中状态
+  const prevPlayerRef = useRef(currentActivePlayer);
   useEffect(() => {
-    setSelectedClientClipUids(new Set());
+    const prev = prevPlayerRef.current;
+    if (prev && prev !== currentActivePlayer) {
+      // 保存旧玩家选择
+      const matchKey = currentMatchIndex;
+      if (!selectionsByMatchRef.current[matchKey]) selectionsByMatchRef.current[matchKey] = {};
+      selectionsByMatchRef.current[matchKey][prev] = selectedClientClipUids;
+      // 恢复新玩家选择
+      const restored = selectionsByMatchRef.current[matchKey]?.[currentActivePlayer];
+      setSelectedClientClipUids(restored ?? new Set());
+    }
+    prevPlayerRef.current = currentActivePlayer;
   }, [currentActivePlayer]);
 
   // 回合合集勾选被清空后，取消其卡片选中（避免看起来已选却不能入队）
@@ -482,8 +507,8 @@ export default function App() {
         setLibraryTotal(null);
         setLibraryHasNextPage((data.items || []).length === limit);
       }
-    } catch {
-      // ignore
+    } catch (err) {
+      console.error("刷新 Demo 库失败:", err);
     } finally {
       if (manageLoading) setLibraryLoading(false);
     }
@@ -801,8 +826,8 @@ export default function App() {
             pacingPersistReadyRef.current = true;
           });
         }
-      } catch {
-        /* ignore */
+      } catch (err) {
+        console.error("加载配置失败:", err);
       }
     })();
     return () => {
@@ -1257,8 +1282,8 @@ export default function App() {
     setSavedRecordWarmupDefaults(obj);
     try {
       await API.put("config", { default_record_warmup: obj });
-    } catch {
-      /* silent */
+    } catch (err) {
+      console.error("保存预热默认值失败:", err);
     }
   }, []);
 
@@ -1322,8 +1347,8 @@ export default function App() {
   const handleSaveConfig = useCallback(async (config) => {
     try {
       await API.put("config", config);
-    } catch {
-      // silent
+    } catch (err) {
+      console.error("保存配置失败:", err);
     }
   }, []);
 
@@ -1397,7 +1422,6 @@ export default function App() {
   }, [obsConfig.host, obsConfig.port, persistObsConfig]);
 
   const persistLlmConfig = useCallback(async () => {
-    await Promise.resolve();
     const c = llmConfigRef.current;
     const payload = {
       provider: c.provider,
@@ -1442,6 +1466,10 @@ export default function App() {
   );
 
   const handleResetDemo = useCallback(() => {
+    if ((parsedMatches?.length > 0 || queue.length > 0) &&
+        !window.confirm("更换 Demo 将清除当前所有解析结果和选择，确认继续？")) {
+      return;
+    }
     setUploadedDemos(null);
     setParsedMatches(null);
     setLibraryDemoIdsByIndex({});
@@ -1451,7 +1479,7 @@ export default function App() {
     setFreezeToDeathRoundsByMatch({});
     setSelectedClientClipUids(new Set());
     setProgressText("");
-  }, []);
+  }, [parsedMatches, queue]);
 
   const handleDetectCs2 = useCallback(async () => {
     try {
@@ -1476,8 +1504,23 @@ export default function App() {
     }
   }, [uploadedDemos, currentMatchIndex]);
 
+  // 切换 match 时保存/恢复选中状态
+  const prevMatchRef = useRef(currentMatchIndex);
   useEffect(() => {
-    setSelectedClientClipUids(new Set());
+    const prev = prevMatchRef.current;
+    if (prev !== currentMatchIndex) {
+      // 保存旧 match 的当前玩家选择
+      const prevPlayer = prevPlayerRef.current;
+      if (prevPlayer) {
+        if (!selectionsByMatchRef.current[prev]) selectionsByMatchRef.current[prev] = {};
+        selectionsByMatchRef.current[prev][prevPlayer] = selectedClientClipUids;
+      }
+      // 恢复新 match 的当前玩家选择
+      const newPlayer = activePlayerTabs[currentMatchIndex] ?? parsedPlayerNames[0] ?? "";
+      const restored = selectionsByMatchRef.current[currentMatchIndex]?.[newPlayer];
+      setSelectedClientClipUids(restored ?? new Set());
+    }
+    prevMatchRef.current = currentMatchIndex;
   }, [currentMatchIndex]);
 
   return (
@@ -1559,7 +1602,8 @@ export default function App() {
           </header>
         )}
 
-        <div className="flex-1 space-y-5 overflow-y-auto px-4 pb-6 pt-3 sm:px-5 sm:pt-4">
+        <div className="flex-1 overflow-y-auto px-4 pb-6 pt-3 sm:px-6 sm:pt-4">
+          <div className="mx-auto max-w-5xl space-y-5">
           <section className="rounded-lg border border-white/10 bg-cs2-bg-card p-3">
             <div className="mb-2 flex items-center justify-between">
               <h3 className="text-xs font-semibold text-zinc-300">本地 Demo 库</h3>
@@ -1962,6 +2006,7 @@ export default function App() {
               )}
             />
           )}
+          </div>
         </div>
 
         {clips.length > 0 && (
@@ -2030,6 +2075,8 @@ export default function App() {
         message={recordingBlockedMessage}
         onClose={() => setRecordingBlockedMessage("")}
       />
+
+      <ToastContainer toasts={toasts} onDismiss={dismissToast} />
     </div>
   );
 }

--- a/frontend/src/components/ActionBar.jsx
+++ b/frontend/src/components/ActionBar.jsx
@@ -45,7 +45,10 @@ export default function ActionBar({
             <button
               type="button"
               disabled={batchRecording}
-              onClick={onAddAllHighlightsAllMatches}
+              onClick={() => {
+                if (!window.confirm("将全部场次的高光片段加入录制队列，确认？")) return;
+                onAddAllHighlightsAllMatches();
+              }}
               className="flex items-center gap-2 rounded-lg border border-cs2-orange/35 bg-cs2-orange/10 px-4 py-2.5 text-xs font-bold text-cs2-orange transition-colors hover:border-cs2-orange/60 hover:bg-cs2-orange/15 disabled:opacity-30"
             >
               <Sparkles className="h-3.5 w-3.5" />

--- a/frontend/src/components/ClipCard.jsx
+++ b/frontend/src/components/ClipCard.jsx
@@ -240,41 +240,47 @@ export default function ClipCard({
               </div>
             )}
 
-            <div className="mb-2 flex flex-wrap items-center gap-1.5">
-              {clip.context_tags?.map((tag, ti) => {
-                const desc = describeTag(tag);
-                return (
-                  <span
-                    key={`${ti}-${tag}`}
-                    title={desc || undefined}
-                    className={`rounded border px-2 py-0.5 text-[10px] font-bold tracking-wide ${cat.bgColor} ${cat.borderColor} ${cat.color} ${desc ? "cursor-help" : ""}`}
-                  >
-                    {tag}
-                  </span>
-                );
-              })}
-              {clip.weapon_used
-                ?.split(" / ")
-                .map((w) => w.trim())
-                .filter(Boolean)
-                .map((w) => (
-                  <span
-                    key={w}
-                    className="rounded border border-cs2-border bg-cs2-bg-input px-2 py-0.5 font-mono text-[10px] text-cs2-text-secondary"
-                  >
-                    {w}
-                  </span>
-                ))}
-              {showKillerBadge && (
-                <span className="rounded border border-rose-500/25 bg-rose-950/40 px-2 py-0.5 text-[10px] font-bold tracking-wide text-rose-300/85">
-                  💀 击杀者: {clip.killer_name}
-                </span>
+            <div className="mb-2 space-y-1.5">
+              {clip.context_tags?.length > 0 && (
+                <div className="flex flex-wrap items-center gap-1.5">
+                  {clip.context_tags.map((tag, ti) => {
+                    const desc = describeTag(tag);
+                    return (
+                      <span
+                        key={`${ti}-${tag}`}
+                        title={desc || undefined}
+                        className={`rounded border px-2 py-1 text-[11px] font-bold tracking-wide ${cat.bgColor} ${cat.borderColor} ${cat.color} ${desc ? "cursor-help" : ""}`}
+                      >
+                        {tag}
+                      </span>
+                    );
+                  })}
+                </div>
               )}
-              {showVictimsBadge && (
-                <span className="rounded border border-emerald-500/20 bg-emerald-950/35 px-2 py-0.5 text-[10px] font-bold tracking-wide text-emerald-400/90">
-                  🎯 击杀: {victimsList.join(", ")}
-                </span>
-              )}
+              <div className="flex flex-wrap items-center gap-1.5">
+                {clip.weapon_used
+                  ?.split(" / ")
+                  .map((w) => w.trim())
+                  .filter(Boolean)
+                  .map((w) => (
+                    <span
+                      key={w}
+                      className="rounded border border-cs2-border bg-cs2-bg-input px-2 py-1 font-mono text-[11px] text-cs2-text-secondary"
+                    >
+                      {w}
+                    </span>
+                  ))}
+                {showKillerBadge && (
+                  <span className="rounded border border-rose-500/25 bg-rose-950/40 px-2 py-1 text-[11px] font-bold tracking-wide text-rose-300/85">
+                    💀 击杀者: {clip.killer_name}
+                  </span>
+                )}
+                {showVictimsBadge && (
+                  <span className="rounded border border-emerald-500/20 bg-emerald-950/35 px-2 py-1 text-[11px] font-bold tracking-wide text-emerald-400/90">
+                    🎯 击杀: {victimsList.join(", ")}
+                  </span>
+                )}
+              </div>
             </div>
 
             <div className="font-mono text-[10px] text-cs2-text-secondary">

--- a/frontend/src/components/ClipList.jsx
+++ b/frontend/src/components/ClipList.jsx
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { Film, User } from "lucide-react";
+import { Film, Flame, Skull, User } from "lucide-react";
 import ClipCard from "./ClipCard";
 
 const NO_QUEUED = new Set();
@@ -114,24 +114,87 @@ export default function ClipList({
         </div>
       )}
 
-      {/* ── 片段卡片列表 ── */}
+      {/* ── 片段卡片列表（按类别分组） ── */}
       {regularClips.length > 0 ? (
-        <div className="grid gap-3">
-          {regularClips.map((clip) => (
-            <ClipCard
-              key={clip.client_clip_uid || clip.clip_id}
-              clip={clip}
-              targetPlayer={targetPlayer}
-              selected={Boolean(clip.client_clip_uid && selectedIds.has(clip.client_clip_uid))}
-              onToggle={onToggle}
-              aiMode={aiMode}
-              inQueue={Boolean(clip.client_clip_uid && queued.has(clip.client_clip_uid))}
-              matchTotalRounds={matchTotalRounds}
-              freezeToDeathDraft={freezeToDeathDraft}
-              onFreezeToDeathDraftChange={onFreezeToDeathDraftChange}
-              roundMontagePickerDisabled={roundMontagePickerDisabled}
-            />
-          ))}
+        <div className="space-y-5">
+          {highlights.length > 0 && (
+            <section>
+              <h3 className="mb-2 flex items-center gap-1.5 text-xs font-semibold text-cs2-highlight">
+                <Flame className="h-3.5 w-3.5" />
+                高光时刻
+                <span className="text-cs2-text-secondary">({highlights.length})</span>
+              </h3>
+              <div className="grid gap-3">
+                {highlights.map((clip) => (
+                  <ClipCard
+                    key={clip.client_clip_uid || clip.clip_id}
+                    clip={clip}
+                    targetPlayer={targetPlayer}
+                    selected={Boolean(clip.client_clip_uid && selectedIds.has(clip.client_clip_uid))}
+                    onToggle={onToggle}
+                    aiMode={aiMode}
+                    inQueue={Boolean(clip.client_clip_uid && queued.has(clip.client_clip_uid))}
+                    matchTotalRounds={matchTotalRounds}
+                    freezeToDeathDraft={freezeToDeathDraft}
+                    onFreezeToDeathDraftChange={onFreezeToDeathDraftChange}
+                    roundMontagePickerDisabled={roundMontagePickerDisabled}
+                  />
+                ))}
+              </div>
+            </section>
+          )}
+          {fails.length > 0 && (
+            <section>
+              <h3 className="mb-2 flex items-center gap-1.5 text-xs font-semibold text-cs2-fail">
+                <Skull className="h-3.5 w-3.5" />
+                下饭操作
+                <span className="text-cs2-text-secondary">({fails.length})</span>
+              </h3>
+              <div className="grid gap-3">
+                {fails.map((clip) => (
+                  <ClipCard
+                    key={clip.client_clip_uid || clip.clip_id}
+                    clip={clip}
+                    targetPlayer={targetPlayer}
+                    selected={Boolean(clip.client_clip_uid && selectedIds.has(clip.client_clip_uid))}
+                    onToggle={onToggle}
+                    aiMode={aiMode}
+                    inQueue={Boolean(clip.client_clip_uid && queued.has(clip.client_clip_uid))}
+                    matchTotalRounds={matchTotalRounds}
+                    freezeToDeathDraft={freezeToDeathDraft}
+                    onFreezeToDeathDraftChange={onFreezeToDeathDraftChange}
+                    roundMontagePickerDisabled={roundMontagePickerDisabled}
+                  />
+                ))}
+              </div>
+            </section>
+          )}
+          {compilations.length > 0 && (
+            <section>
+              <h3 className="mb-2 flex items-center gap-1.5 text-xs font-semibold text-cs2-compilation">
+                <Film className="h-3.5 w-3.5" />
+                跨回合合集
+                <span className="text-cs2-text-secondary">({compilations.length})</span>
+              </h3>
+              <div className="grid gap-3">
+                {compilations.map((clip) => (
+                  <ClipCard
+                    key={clip.client_clip_uid || clip.clip_id}
+                    clip={clip}
+                    targetPlayer={targetPlayer}
+                    selected={Boolean(clip.client_clip_uid && selectedIds.has(clip.client_clip_uid))}
+                    onToggle={onToggle}
+                    aiMode={aiMode}
+                    inQueue={Boolean(clip.client_clip_uid && queued.has(clip.client_clip_uid))}
+                    matchTotalRounds={matchTotalRounds}
+                    freezeToDeathDraft={freezeToDeathDraft}
+                    onFreezeToDeathDraftChange={onFreezeToDeathDraftChange}
+                    roundMontagePickerDisabled={roundMontagePickerDisabled}
+                  />
+                ))}
+              </div>
+            </section>
+          )}
         </div>
       ) : (
         showTabs && (

--- a/frontend/src/components/DemoUpload.jsx
+++ b/frontend/src/components/DemoUpload.jsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from "react";
+import { useState, useCallback, useRef } from "react";
 import { Upload, FileCode2 } from "lucide-react";
 
 function collectDemFiles(fileList) {
@@ -9,10 +9,31 @@ function collectDemFiles(fileList) {
 /** @param {{ onUpload: (files: File[]) => void }} props */
 export default function DemoUpload({ onUpload }) {
   const [dragOver, setDragOver] = useState(false);
+  const dragCounterRef = useRef(0);
+
+  const handleDragEnter = useCallback((e) => {
+    e.preventDefault();
+    dragCounterRef.current += 1;
+    setDragOver(true);
+  }, []);
+
+  const handleDragLeave = useCallback((e) => {
+    e.preventDefault();
+    dragCounterRef.current -= 1;
+    if (dragCounterRef.current <= 0) {
+      dragCounterRef.current = 0;
+      setDragOver(false);
+    }
+  }, []);
+
+  const handleDragOver = useCallback((e) => {
+    e.preventDefault();
+  }, []);
 
   const handleDrop = useCallback(
     (e) => {
       e.preventDefault();
+      dragCounterRef.current = 0;
       setDragOver(false);
       const dems = collectDemFiles(e.dataTransfer.files);
       if (dems.length) onUpload(dems);
@@ -31,11 +52,9 @@ export default function DemoUpload({ onUpload }) {
 
   return (
     <div
-      onDragOver={(e) => {
-        e.preventDefault();
-        setDragOver(true);
-      }}
-      onDragLeave={() => setDragOver(false)}
+      onDragEnter={handleDragEnter}
+      onDragOver={handleDragOver}
+      onDragLeave={handleDragLeave}
       onDrop={handleDrop}
       className={`relative flex flex-col items-center justify-center rounded-xl border-2 border-dashed transition-all duration-200 cursor-pointer py-14 sm:py-16 ${
         dragOver
@@ -48,7 +67,7 @@ export default function DemoUpload({ onUpload }) {
         accept=".dem"
         multiple
         onChange={handleFileInput}
-        className="absolute inset-0 h-full w-full cursor-pointer opacity-0"
+        className="absolute inset-0 z-10 h-full w-full cursor-pointer opacity-0"
       />
 
       <div

--- a/frontend/src/components/MemeDeathMontageCard.jsx
+++ b/frontend/src/components/MemeDeathMontageCard.jsx
@@ -33,9 +33,9 @@ export default function MemeDeathMontageCard({
   return (
     <div
       className={[
-        "relative overflow-hidden rounded-2xl border-2 p-5 md:p-6",
-        "border-red-500/70 shadow-[0_0_24px_rgba(239,68,68,0.45),0_0_48px_rgba(190,24,93,0.2),inset_0_1px_0_rgba(255,255,255,0.06)]",
-        "bg-gradient-to-br from-rose-950/50 via-red-950/40 to-fuchsia-950/35",
+        "relative overflow-hidden rounded-xl border p-5 md:p-6",
+        "border-red-500/40 shadow-md",
+        "bg-gradient-to-br from-rose-950/25 via-red-950/20 to-fuchsia-950/15",
       ].join(" ")}
     >
       <div
@@ -54,7 +54,7 @@ export default function MemeDeathMontageCard({
               打包录制
             </span>
           </div>
-          <h3 className="text-xl font-black leading-tight tracking-tight text-white drop-shadow-[0_0_12px_rgba(0,0,0,0.5)] md:text-2xl lg:text-3xl">
+          <h3 className="text-lg font-black leading-tight tracking-tight text-white">
             👨‍🔬 节目效果专属：研发全过程{" "}
             <span className="whitespace-nowrap text-red-200">
               (本局共 {totalDeathsInMatch} 次死亡)

--- a/frontend/src/components/PlayerSelect.jsx
+++ b/frontend/src/components/PlayerSelect.jsx
@@ -34,9 +34,8 @@ function normalizePlayer(p) {
 }
 
 const MEME_BADGE_CLASS =
-  "inline-flex shrink-0 items-center rounded-md px-2 py-0.5 text-sm font-black tracking-tight text-white " +
-  "bg-gradient-to-r from-pink-500 via-fuchsia-500 to-purple-600 " +
-  "shadow-[0_0_14px_rgba(236,72,153,0.85),0_0_28px_rgba(168,85,247,0.45)]";
+  "inline-flex shrink-0 items-center rounded-md px-2 py-0.5 text-xs font-bold tracking-tight text-fuchsia-300 " +
+  "bg-fuchsia-600/20 border border-fuchsia-500/30";
 
 /** selected: string[] — 已选玩家名称数组 */
 function PlayerRow({ player, selected, onSelect }) {

--- a/frontend/src/components/RecordingQueueDrawer.jsx
+++ b/frontend/src/components/RecordingQueueDrawer.jsx
@@ -145,11 +145,8 @@ function PacingMicroPanel({ item, expanded, onToggleExpand, updateItemPacing }) 
             </div>
           </div>
 
-          <details className="group rounded border border-white/[0.08] bg-black/20 [&_summary::-webkit-details-marker]:hidden">
-            <summary className="cursor-pointer list-none px-2 py-1.5 text-[10px] font-semibold text-zinc-400 transition-colors hover:text-cs2-orange">
-              <span className="select-none">🔽 展开专业跳剪参数 (Pro)</span>
-            </summary>
-            <div className="space-y-3 border-t border-white/[0.06] px-2 pb-2 pt-2">
+          <div className="space-y-3 border-t border-white/[0.06] pt-2">
+              <p className="text-[9px] font-bold uppercase tracking-wider text-zinc-600">专业跳剪参数</p>
               <label
                 className="block text-[10px] text-zinc-500"
                 title="触发闪切前的保留时间(适合保留切刀)"
@@ -213,8 +210,7 @@ function PacingMicroPanel({ item, expanded, onToggleExpand, updateItemPacing }) 
                 </div>
               </label>
             </div>
-          </details>
-        </div>
+          </div>
       ) : null}
     </div>
   );
@@ -812,7 +808,10 @@ export default function RecordingQueueDrawer({
           {queue.length > 0 && (
             <button
               type="button"
-              onClick={onClear}
+              onClick={() => {
+                if (!window.confirm(`确认清空全部 ${queue.length} 个录制队列项？`)) return;
+                onClear();
+              }}
               className="w-full rounded-md border border-cs2-border py-2 text-xs font-semibold text-zinc-400 hover:border-red-500/40 hover:text-red-300"
             >
               清空队列

--- a/frontend/src/components/RoundMontageRoundPicker.jsx
+++ b/frontend/src/components/RoundMontageRoundPicker.jsx
@@ -39,7 +39,7 @@ export default function RoundMontageRoundPicker({ maxRounds, picked, disabled = 
           未勾选时不可加入录制队列。解析在未勾选时仍按整局合规非赛后回合生成合辑；勾选后再解析可只生成所选回合。
         </p>
       ) : null}
-      <div className="max-h-24 overflow-y-auto rounded border border-white/[0.06] bg-black/35 p-1.5">
+      <div className="max-h-32 overflow-y-auto rounded border border-white/[0.06] bg-black/35 p-1.5">
         <div className="flex flex-wrap gap-1">
           {Array.from({ length: n }, (_, i) => i + 1).map((r) => {
             const on = set.has(r);
@@ -50,7 +50,7 @@ export default function RoundMontageRoundPicker({ maxRounds, picked, disabled = 
                 disabled={disabled}
                 title={`第 ${r} 回合`}
                 onClick={() => toggle(r)}
-                className={`min-w-[1.75rem] rounded border px-1 py-0.5 font-mono text-[9px] font-semibold tabular-nums transition-colors ${
+                className={`min-w-[2.25rem] rounded border px-1.5 py-1 font-mono text-[10px] font-semibold tabular-nums transition-colors ${
                   on
                     ? "border-cs2-orange/45 bg-cs2-orange/15 text-cs2-orange"
                     : "border-white/10 bg-white/[0.03] text-zinc-500 hover:border-white/18"

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -18,7 +18,7 @@ import {
 } from "lucide-react";
 
 const PROVIDER_PRESETS = {
-  deepseek:    { label: "DeepSeek",        model: "deepseek-chat",          base_url: "https://api.deepseek.com",                  local: false },
+  deepseek:    { label: "DeepSeek",        model: "deepseek-v4-flash",      base_url: "https://api.deepseek.com",                  local: false },
   openai:      { label: "OpenAI",          model: "gpt-4o",                base_url: "https://api.openai.com",                    local: false },
   qwen:        { label: "通义千问 (Qwen)", model: "qwen-plus",             base_url: "https://dashscope.aliyuncs.com/compatible-mode", local: false },
   glm:         { label: "智谱 (GLM)",      model: "glm-4-flash",           base_url: "https://open.bigmodel.cn/api/paas",         local: false },
@@ -56,14 +56,14 @@ export default function Sidebar({
   onSaveExpectedParsePlayers,
 }) {
   const [obsOpen, setObsOpen] = useState(true);
-  const [cs2Open, setCs2Open] = useState(true);
+  const [cs2Open, setCs2Open] = useState(false);
   const [llmOpen, setLlmOpen] = useState(true);
-  const [expectedPlayersOpen, setExpectedPlayersOpen] = useState(true);
+  const [expectedPlayersOpen, setExpectedPlayersOpen] = useState(false);
   const [obsTestResult, setObsTestResult] = useState(null);
   const [obsTesting, setObsTesting] = useState(false);
   const [detectingCs2, setDetectingCs2] = useState(false);
   const [showApiKey, setShowApiKey] = useState(false);
-  const [watchOpen, setWatchOpen] = useState(true);
+  const [watchOpen, setWatchOpen] = useState(false);
   const [watchPathInput, setWatchPathInput] = useState("");
 
   const handleDetectCs2 = async () => {
@@ -118,7 +118,7 @@ export default function Sidebar({
   const isLocal = currentPreset?.local ?? false;
 
   return (
-    <aside className="w-72 bg-cs2-bg-sidebar border-r border-cs2-border flex flex-col overflow-y-auto shrink-0">
+    <aside className="w-76 bg-cs2-bg-sidebar border-r border-cs2-border flex flex-col overflow-y-auto shrink-0">
       {/* Logo */}
       <div className="px-4 py-5 border-b border-cs2-border">
         <div className="flex items-center gap-2">

--- a/frontend/src/components/Toast.jsx
+++ b/frontend/src/components/Toast.jsx
@@ -1,0 +1,56 @@
+import { useEffect, useState } from "react";
+import { X, CheckCircle2, AlertCircle, Info } from "lucide-react";
+
+const TYPE_CONFIG = {
+  success: { icon: CheckCircle2, color: "text-emerald-400", border: "border-emerald-500/30" },
+  error: { icon: AlertCircle, color: "text-rose-400", border: "border-rose-500/30" },
+  info: { icon: Info, color: "text-sky-400", border: "border-sky-500/30" },
+};
+
+function ToastItem({ toast, onDismiss }) {
+  const [exiting, setExiting] = useState(false);
+  const config = TYPE_CONFIG[toast.type] || TYPE_CONFIG.info;
+  const Icon = config.icon;
+
+  useEffect(() => {
+    if (toast.duration <= 0) return;
+    const timer = setTimeout(() => setExiting(true), toast.duration - 300);
+    return () => clearTimeout(timer);
+  }, [toast.duration]);
+
+  useEffect(() => {
+    if (!exiting) return;
+    const timer = setTimeout(() => onDismiss(toast.id), 300);
+    return () => clearTimeout(timer);
+  }, [exiting, toast.id, onDismiss]);
+
+  return (
+    <div
+      className={`flex items-start gap-2.5 rounded-lg border ${config.border} bg-cs2-bg-card px-3.5 py-2.5 shadow-lg transition-all duration-300 ${
+        exiting ? "translate-x-full opacity-0" : "translate-x-0 opacity-100"
+      }`}
+    >
+      <Icon className={`mt-0.5 h-4 w-4 shrink-0 ${config.color}`} />
+      <p className="min-w-0 flex-1 text-xs leading-relaxed text-zinc-200">{toast.message}</p>
+      <button
+        type="button"
+        onClick={() => onDismiss(toast.id)}
+        className="shrink-0 rounded p-0.5 text-zinc-500 hover:text-zinc-300"
+      >
+        <X className="h-3.5 w-3.5" />
+      </button>
+    </div>
+  );
+}
+
+export default function ToastContainer({ toasts, onDismiss }) {
+  if (toasts.length === 0) return null;
+
+  return (
+    <div className="fixed bottom-4 right-4 z-[100] flex max-w-sm flex-col gap-2">
+      {toasts.map((t) => (
+        <ToastItem key={t.id} toast={t} onDismiss={onDismiss} />
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## 布局优化
- 主内容区增加 max-w-5xl (1024px) 宽度约束，宽屏不再拉伸
- 侧边栏宽度从 w-72 (288px) 调整为 w-76 (304px)
- 侧边栏非核心分区默认折叠 (CS2路径/监听目录/预期玩家)

## 信息密度降低
- ClipList 按 "高光/下饭/跨回合合集" 分组展示，每组有彩色标题
- ClipCard 标签按语义分两行，字号从 10px 提升到 11px
- MemeDeathMontageCard 视觉降级，去掉 glow shadow
- RoundMontageRoundPicker 按钮从 28px 增大到 36px
- PlayerSelect Meme badge 去掉渐变和 glow
- RecordingQueueDrawer Pro 参数从三层嵌套简化为两层平铺

## 交互修复
- "更换 Demo" / "清空队列" / "全部场次高光入队" 增加确认对话框
- 切换 player/match tab 时按维度保存/恢复选择状态
- 新增 Toast 通知组件，替换静默错误吞没
- 清理 await Promise.resolve() 废代码
- DemoUpload 拖拽修复 (drag counter 防止子元素触发 dragLeave)

## 其他
- DeepSeek 默认模型改为 deepseek-v4-flash