### PR TITLE
feat: isolate user data into data/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,9 @@ node_modules/
 frontend/dist/
 .vite/
 
-# Config with secrets (JSON)
+# User data directory (config, db, logs)
+data/
+# Legacy config paths (before data/ migration)
 backend/config.json
 cs2-insight.config.json
 

--- a/backend/app/env_utils.py
+++ b/backend/app/env_utils.py
@@ -8,6 +8,7 @@
 import json
 import os
 import re
+import shutil
 from pathlib import Path
 from typing import Any, Optional
 
@@ -18,18 +19,24 @@ except ImportError:
 
 from pydantic import BaseModel, ConfigDict, Field
 
-# 轻量 JSON 配置：默认在仓库根目录 cs2-insight.config.json（可用环境变量 CS2_INSIGHT_CONFIG 覆盖绝对路径）
+# 用户数据统一放在 data/ 目录，版本升级时只需保留该目录即可迁移。
 _BACKEND_DIR = Path(__file__).resolve().parent.parent
 _REPO_ROOT = _BACKEND_DIR.parent
+_DATA_DIR = _REPO_ROOT / "data"
 _LEGACY_CONFIG_PATH = _BACKEND_DIR / "config.json"
 _DEFAULT_CONFIG_FILENAME = "cs2-insight.config.json"
+_EXAMPLE_CONFIG = _REPO_ROOT / "cs2-insight.config.example.json"
 
 
 def resolve_config_path() -> Path:
+    """返回用户配置文件路径（data/cs2-insight.config.json）。
+
+    可通过环境变量 ``CS2_INSIGHT_CONFIG`` 覆写为绝对路径。
+    """
     override = os.environ.get("CS2_INSIGHT_CONFIG", "").strip()
     if override:
         return Path(override).expanduser()
-    return _REPO_ROOT / _DEFAULT_CONFIG_FILENAME
+    return _DATA_DIR / _DEFAULT_CONFIG_FILENAME
 
 DEFAULT_STEAM_PATHS = [
     Path(r"C:\Program Files (x86)\Steam"),
@@ -181,14 +188,37 @@ def load_config() -> AppConfig:
     if path.is_file():
         raw = _parse_config_json_file(path)
         return AppConfig(**raw)
-    if _LEGACY_CONFIG_PATH.is_file():
-        raw = _parse_config_json_file(_LEGACY_CONFIG_PATH)
-        cfg = AppConfig(**raw)
-        save_config(cfg)
-        return cfg
+
+    # 从旧位置自动迁移
+    _migrate_old_config(path)
+
+    if path.is_file():
+        raw = _parse_config_json_file(path)
+        return AppConfig(**raw)
+
+    # 首次启动：从模板复制一份，方便用户在此基础上修改
+    if _EXAMPLE_CONFIG.is_file():
+        _DATA_DIR.mkdir(parents=True, exist_ok=True)
+        shutil.copy(str(_EXAMPLE_CONFIG), str(path))
+        raw = _parse_config_json_file(path)
+        return AppConfig(**raw)
+
     cfg = AppConfig()
     save_config(cfg)
     return cfg
+
+
+def _migrate_old_config(target: Path) -> None:
+    """将旧位置的配置文件迁移到 data/ 目录。"""
+    candidates = [
+        _REPO_ROOT / _DEFAULT_CONFIG_FILENAME,   # 旧：仓库根目录
+        _LEGACY_CONFIG_PATH,                     # 旧：backend/config.json
+    ]
+    for old in candidates:
+        if old.is_file() and old != target:
+            _DATA_DIR.mkdir(parents=True, exist_ok=True)
+            shutil.copy(str(old), str(target))
+            break
 
 
 def save_config(cfg: AppConfig) -> None:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -66,6 +66,11 @@ except Exception:
     logging.getLogger(__name__).exception("Backend file logging setup failed")
 
 DB_PATH = resolve_config_path().parent / "cs2-insight.db"
+# 从仓库根目录迁移旧数据库到 data/
+_OLD_DB_PATH = DB_PATH.parent.parent / "cs2-insight.db"
+if _OLD_DB_PATH.is_file() and not DB_PATH.is_file():
+    DB_PATH.parent.mkdir(parents=True, exist_ok=True)
+    shutil.move(str(_OLD_DB_PATH), str(DB_PATH))
 demo_db = DemoDB(DB_PATH)
 montage_db = MontageDB(DB_PATH)
 demo_watcher: DemoWatcher | None = None


### PR DESCRIPTION
## 概述

将用户数据（配置、数据库、日志）统一放到 `data/` 目录，版本升级时只需保留该目录即可无缝迁移所有数据。

## 改前 vs 改后

```
改前（散落在根目录）              改后（集中在 data/）
├── cs2-insight.db          →    ├── data/
├── cs2-insight.config.json →    │   ├── cs2-insight.db
├── logs/                   →    │   ├── cs2-insight.config.json
├── backend/                     │   └── logs/
├── ...                          ├── cs2-insight.config.example.json  (模板)
                                 ├── backend/
                                 └── ...
```

## 升级流程

1. 解压新版本 ZIP 到新文件夹
2. 把旧 `data/` 文件夹拖进去
3. 运行 `启动.bat`

## 自动迁移

首次启动时自动兼容旧版：

- 旧版根目录的 `cs2-insight.config.json` → 复制到 `data/`
- 旧版 `backend/config.json` → 复制到 `data/`
- 旧版根目录的 `cs2-insight.db` → 移动到 `data/`
- 全新安装 → 从 `cs2-insight.config.example.json` 复制模板

## 改动文件

| 文件 | 改动 |
|------|------|
| `.gitignore` | 新增 `data/` |
| `env_utils.py` | 配置路径指向 `data/`；加迁移 + 首次复制逻辑 |
| `main.py` | 启动时迁移旧数据库到 `data/` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)