### PR TITLE
OBS 自动拉起 / 解耦必须运行 / 持久化验证

### DIFF
--- a/backend/app/env_utils.py
+++ b/backend/app/env_utils.py
@@ -292,6 +292,10 @@ class OBSConfig(BaseModel):
     host: str = "localhost"
     port: int = 4455
     password: str = ""
+    # OBS 可执行文件完整路径，用于录制前自动启动 OBS
+    obs_path: str = ""
+    # OBS 配置中心"配置检查"是否通过过（WebSocket 连接成功）
+    obs_config_verified: bool = False
 
 
 class LLMConfig(BaseModel):

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -695,6 +695,21 @@ def open_config_data_dir():
         return {"ok": False, "path": folder, "message": "无法自动打开目录，请手动复制路径。"}
 
 
+@app.post("/api/config/detect-obs")
+def detect_obs_path_save():
+    """扫描常见安装路径并写入 cs2-insight.config.json 中的 obs.obs_path。"""
+    path = _auto_detect_obs_path()
+    if not path:
+        raise HTTPException(
+            404,
+            "未找到 OBS（obs64.exe）。请确认已安装 OBS，或在 OBS 配置中心手动填写完整路径。",
+        )
+    cfg = load_config()
+    cfg.obs.obs_path = path
+    save_config(cfg)
+    return {"obs_path": path}
+
+
 @app.post("/api/config/test-llm")
 async def test_llm_connection():
     """轻量探测当前大模型配置是否可用（本地 HTTP 或云端一次极短补全）。"""
@@ -784,6 +799,8 @@ async def update_config(payload: ConfigPayload):
         elif raw_pw:
             cfg.obs.password = raw_pw
         # 空字符串：GET 脱敏后输入框为空或未提交密码，不覆盖已保存的密码
+        if o.obs_path is not None:
+            cfg.obs.obs_path = str(o.obs_path).strip()
     if payload.llm:
         if payload.llm.api_key and not payload.llm.api_key.startswith("****"):
             cfg.llm = payload.llm
@@ -907,6 +924,34 @@ def merge_obs_for_connection(payload: Optional[OBSConfig], saved: OBSConfig) -> 
     return OBSConfig(host=host, port=port, password=password)
 
 
+_DEFAULT_OBS_PATHS = (
+    r"C:\Program Files\obs-studio\bin\64bit\obs64.exe",
+    r"C:\Program Files (x86)\obs-studio\bin\64bit\obs64.exe",
+)
+
+
+def _auto_detect_obs_path() -> Optional[str]:
+    """尝试自动探测 OBS 可执行文件路径。"""
+    for p in _DEFAULT_OBS_PATHS:
+        pp = Path(p)
+        if pp.is_file():
+            return str(pp)
+    # 也尝试从 PATH 中查找
+    found = shutil.which("obs64.exe") or shutil.which("obs.exe")
+    if found:
+        return found
+    return None
+
+
+def _normalize_obs_path_auto_detect(cfg: AppConfig) -> None:
+    """OBS 验证成功后：若 obs_path 为空，尝试自动探测并写入配置。"""
+    if cfg.obs.obs_path and Path(cfg.obs.obs_path).is_file():
+        return
+    detected = _auto_detect_obs_path()
+    if detected:
+        cfg.obs.obs_path = detected
+
+
 # ─── Setup status endpoint ─────────────────────────────────────
 
 def _setup_status_obs_handshake_timeout_sec() -> float:
@@ -920,9 +965,44 @@ def _setup_status_obs_handshake_timeout_sec() -> float:
     return 4.0
 
 
+@app.get("/api/config/quick-check")
+def config_quick_check():
+    """轻量配置核查：返回各项配置是否已检测通过（OBS 为 obs_config_verified 标记，
+    CS2 路径为实际文件存在性）。**不尝试连接 OBS**。
+    供首页引导页、录制队列页状态展示使用，避免 /api/status/setup 的 WebSocket 开销。
+    """
+    cfg = load_config()
+    cfg = ensure_cs2_path(cfg)
+
+    cs2_path_ok = bool(cfg.cs2_path and Path(cfg.cs2_path).is_file())
+
+    ffmpeg_ok = False
+    if cfg.ffmpeg_path:
+        ffmpeg_ok = Path(cfg.ffmpeg_path).is_file()
+    else:
+        ffmpeg_ok = shutil.which("ffmpeg") is not None
+
+    ai_key_ok = llm_api_key_configured(cfg.llm.api_key) or llm_base_url_is_local_host(
+        cfg.llm.base_url
+    )
+
+    try:
+        port_val = int(cfg.obs.port) if cfg.obs.port is not None else 0
+    except (TypeError, ValueError):
+        port_val = 0
+    return {
+        "obs_configured": cfg.obs.obs_config_verified,
+        "cs2_path_ok": cs2_path_ok,
+        "ffmpeg_ok": ffmpeg_ok,
+        "ai_key_ok": ai_key_ok,
+        "cs2_path": cfg.cs2_path or "",
+        "ffmpeg_path": cfg.ffmpeg_path or "",
+    }
+
+
 @app.get("/api/status/setup")
 def setup_status():
-    """快速核查四项配置是否就绪，供新手引导页轮询。"""
+    """快速核查四项配置是否就绪，供录制启动前调用（含 OBS 真实连接检测）。"""
     cfg = load_config()
     cfg = ensure_cs2_path(cfg)
 
@@ -952,6 +1032,12 @@ def setup_status():
         probe_timeout = _setup_status_obs_handshake_timeout_sec()
         result = director.test_obs_connection(handshake_timeout_sec=probe_timeout)
         obs_connected = bool(result.get("ok", False))
+
+        # OBS 验证成功后自动写入配置文件，标记为已验证
+        if obs_connected:
+            _normalize_obs_path_auto_detect(cfg)
+            cfg.obs.obs_config_verified = True
+            save_config(cfg)
     except Exception:
         obs_connected = False
 
@@ -967,19 +1053,111 @@ def setup_status():
 
 # ─── OBS endpoints ─────────────────────────────────────────────
 
-@app.post("/api/obs/test")
-def test_obs(payload: OBSConfig | None = Body(default=None)):
-    from .obs_director import OBSDirector
+@app.post("/api/obs/config-check")
+def obs_config_check(payload: OBSConfig | None = Body(default=None)):
+    """配置检查：先测路径（拉起 OBS），再测连接。"""
+    import time as _time
 
     cfg = load_config()
     obs_use = merge_obs_for_connection(payload, cfg.obs)
-    director = OBSDirector(
-        obs_use,
-        cfg.cs2_path,
-        cs2_extra_launch_args=cfg.cs2_extra_launch_args,
-        record_inject_console_lines=cfg.record_inject_console_lines,
-    )
-    return director.test_obs_connection()
+
+    path_ok = False
+    launched_obs = False
+    connected = False
+    obs_version = None
+
+    obs_path = (obs_use.obs_path or cfg.obs.obs_path or "").strip()
+    logger.info("[OBS config-check] obs_path=%r", obs_path)
+
+    if obs_path and Path(obs_path).is_file():
+        running = _is_obs_process_running(obs_path)
+        logger.info("[OBS config-check] Path OK, OBS already running=%s", running)
+        if not running:
+            logger.info("[OBS config-check] Launching OBS: %s", obs_path)
+            try:
+                subprocess.Popen([obs_path], cwd=str(Path(obs_path).parent))
+                launched_obs = True
+                path_ok = True
+                # 轮询等待 OBS 进程出现，最多 15 秒
+                for _attempt in range(30):
+                    if _is_obs_process_running(obs_path):
+                        break
+                    _time.sleep(0.5)
+                else:
+                    logger.warning("[OBS config-check] OBS did not appear after 15s; continuing anyway")
+                _time.sleep(1)
+            except Exception as e:
+                logger.error("[OBS config-check] Failed to launch OBS: %s", e)
+                return {"path_ok": False, "error": f"无法启动 OBS: {e}"}
+        else:
+            path_ok = True
+    elif obs_path:
+        logger.warning("[OBS config-check] Path configured but file not found: %s", obs_path)
+        return {"path_ok": False, "error": "OBS 路径不存在"}
+    else:
+        logger.info("[OBS config-check] No obs_path configured, skipping launch")
+        return {"path_ok": False, "connected": False, "error": "请先配置 OBS 路径，再点击配置检查"}
+
+    # 2) 测试 WebSocket 连接
+    try:
+        from .obs_director import OBSDirector
+        director = OBSDirector(obs_use, cfg.cs2_path)
+        result = director.test_obs_connection()
+        connected = bool(result.get("ok"))
+        obs_version = result.get("obs_version")
+        if connected:
+            _normalize_obs_path_auto_detect(cfg)
+            cfg.obs.obs_config_verified = True
+            save_config(cfg)
+    except Exception:
+        connected = False
+        obs_version = None
+
+    return {
+        "path_ok": path_ok,
+        "connected": connected,
+        "obs_version": obs_version,
+        "launched_obs": launched_obs,
+    }
+
+
+def _is_obs_process_running(obs_path: str) -> bool:
+    """检查 OBS 进程是否已在运行（Windows 上按可执行文件名匹配）。"""
+    import subprocess as _sp
+    try:
+        exe_name = Path(obs_path).name
+        result = _sp.run(
+            ["tasklist", "/FI", f"IMAGENAME eq {exe_name}", "/NH", "/FO", "CSV"],
+            capture_output=True, text=True, timeout=10,
+        )
+        return exe_name.lower() in result.stdout.lower()
+    except Exception:
+        return False
+
+
+@app.post("/api/obs/is-running")
+def obs_is_running():
+    """检查 OBS 进程是否在运行（不尝试连接 WebSocket）。"""
+    cfg = load_config()
+    obs_path = (cfg.obs.obs_path or "").strip()
+    running = _is_obs_process_running(obs_path) if obs_path else False
+    return {"running": running, "obs_path": obs_path}
+
+
+@app.post("/api/obs/launch")
+def obs_launch():
+    """拉起 OBS 进程（不等待 WebSocket）。"""
+    import time as _t
+    cfg = load_config()
+    obs_path = (cfg.obs.obs_path or "").strip()
+    if not obs_path or not Path(obs_path).is_file():
+        raise HTTPException(400, "OBS 路径未配置或文件不存在")
+    try:
+        subprocess.Popen([obs_path], cwd=str(Path(obs_path).parent))
+        _t.sleep(2)
+    except Exception as e:
+        raise HTTPException(400, f"无法启动 OBS: {e}")
+    return {"ok": True}
 
 
 @app.get("/api/obs-config/status")

--- a/backend/app/recording/api.py
+++ b/backend/app/recording/api.py
@@ -488,6 +488,23 @@ async def execute_recording_queue(req: QueueRecordingRequest) -> list[dict]:
             pass
     obs_cfg = _merge_obs(obs_cfg_override, cfg.obs)
 
+    # Pre-recording OBS connection check — verify OBS is reachable before
+    # launching CS2, so we fail fast rather than wasting ~60s on CS2 warmup
+    # only to discover OBS is down.
+    try:
+        _pre_obs_client = OBSClient(obs_cfg)
+        _pre_obs_client.connect()
+        try:
+            _pre_obs_client.disconnect()
+        except Exception:
+            pass
+        logger.info("[RecordingV3] OBS pre-check: connection OK")
+    except OBSConnectionError as e:
+        raise HTTPException(
+            400,
+            f"无法连接 OBS：{e}。请在开始录制前确认 OBS 已运行且 WebSocket 配置正确。",
+        )
+
     # Resolve demo paths: replace filename/relative refs with absolute paths.
     resolved_requests = []
     for dto in req.requests:

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -58,7 +58,7 @@ export default function App() {
       window.electron.isPackaged().then(setIsPackaged);
     }
   }, []);
-  const [obsConfig, setObsConfig] = useState({ host: "localhost", port: 4455, password: "" });
+  const [obsConfig, setObsConfig] = useState({ host: "localhost", port: 4455, password: "", obs_path: "" });
   /** 服务器是否已有 OBS 密码（GET /api/config 返回脱敏或本地刚保存成功） */
   const [obsHasSavedPassword, setObsHasSavedPassword] = useState(false);
   /** 用户是否正在编辑密码框（用于失焦时恢复“已保存”提示） */
@@ -1585,7 +1585,7 @@ export default function App() {
     }
   }, [setProgressText, refreshCommonParamsFromServer]);
 
-  const openBatchWarmup = useCallback(() => {
+  const openBatchWarmup = useCallback(async () => {
     if (!queue.length) return;
     if (configBackupStatus?.restore_required) {
       setRecordingBlockedMessage(
@@ -1593,10 +1593,36 @@ export default function App() {
       );
       return;
     }
+    // 1) 检查 OBS 进程是否在运行
+    try {
+      const { data: runData } = await API.post("/obs/is-running");
+      if (!runData.running) {
+        setProgressText("检测到 OBS 未运行，正在自动启动…");
+        await API.post("/obs/launch");
+        await new Promise((r) => setTimeout(r, 3000));
+        setProgressText("OBS 已启动，正在检测连接…");
+      }
+    } catch (e) {
+      setProgressText(`OBS 启动失败: ${e.response?.data?.detail || e.message}`);
+      return;
+    }
+    // 2) 测试 WebSocket 连接
+    try {
+      const { data } = await API.get("/status/setup");
+      if (!data?.obs_connected) {
+        setProgressText(
+          "无法连接 OBS。请在开始录制前确认 OBS 已运行且 WebSocket 配置正确。",
+        );
+        return;
+      }
+    } catch (e) {
+      setProgressText("OBS 连通性检测失败，请稍后重试。");
+      return;
+    }
     setQueueDrawerOpen(false);
     setWarmupIntent("batch");
     setRecordWarmupOpen(true);
-  }, [queue.length, configBackupStatus?.restore_required]);
+  }, [queue.length, configBackupStatus?.restore_required, setProgressText]);
 
   const handleWarmupConfirm = useCallback(
     async (warmupPayload) => {
@@ -1758,6 +1784,10 @@ export default function App() {
     if (pw && !pw.startsWith("****")) {
       obs.password = pw;
     }
+    const obsPath = String(o.obs_path ?? "").trim();
+    if (obsPath) {
+      obs.obs_path = obsPath;
+    }
     try {
       await API.put("config", { obs });
       if (pw && !pw.startsWith("****")) {
@@ -1797,7 +1827,7 @@ export default function App() {
       void persistObsConfig();
     }, 500);
     return () => clearTimeout(t);
-  }, [obsConfig.host, obsConfig.port, persistObsConfig]);
+  }, [obsConfig.host, obsConfig.port, obsConfig.obs_path, persistObsConfig]);
 
   const persistLlmConfig = useCallback(async () => {
     await Promise.resolve();

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -2,8 +2,6 @@ import { useState, useEffect } from "react";
 import API from "../api/api";
 import {
   Settings,
-  Wifi,
-  WifiOff,
   Brain,
   Zap,
   Eye,
@@ -68,8 +66,6 @@ export default function Sidebar({
   const [cs2Open, setCs2Open] = useState(true);
   const [llmOpen, setLlmOpen] = useState(true);
   const [expectedPlayersOpen, setExpectedPlayersOpen] = useState(true);
-  const [obsTestResult, setObsTestResult] = useState(null);
-  const [obsTesting, setObsTesting] = useState(false);
   const [detectingCs2, setDetectingCs2] = useState(false);
   const [showApiKey, setShowApiKey] = useState(false);
   const [watchOpen, setWatchOpen] = useState(true);
@@ -112,22 +108,6 @@ export default function Sidebar({
       await onDetectCs2();
     } finally {
       setDetectingCs2(false);
-    }
-  };
-
-  const testObs = async () => {
-    setObsTesting(true);
-    setObsTestResult(null);
-    try {
-      const { data } = await API.post("/obs/test", obsConfig);
-      setObsTestResult(data);
-      if (data?.ok) {
-        await onPersistObs?.();
-      }
-    } catch (e) {
-      setObsTestResult({ ok: false, error: e?.response?.data?.detail || e.message });
-    } finally {
-      setObsTesting(false);
     }
   };
 
@@ -293,22 +273,6 @@ export default function Sidebar({
                 className="w-full rounded-md border border-cs2-border bg-cs2-bg-input px-3 py-2 font-mono text-xs text-cs2-text-primary transition-colors placeholder:text-cs2-text-secondary/50 focus:border-cs2-accent/50 focus:outline-none"
               />
             </div>
-            <button
-              onClick={testObs}
-              disabled={obsTesting}
-              className="w-full py-2 rounded-md text-xs font-semibold bg-cs2-bg-input border border-cs2-border hover:border-cs2-accent/50 transition-colors disabled:opacity-50"
-            >
-              {obsTesting ? "测试中..." : "测试连接"}
-            </button>
-            {obsTestResult && (
-              <div className={`text-[11px] font-mono px-2 py-1.5 rounded ${obsTestResult.ok ? "text-cs2-highlight bg-cs2-highlight/10" : "text-cs2-fail bg-cs2-fail/10"}`}>
-                {obsTestResult.ok ? (
-                  <span className="flex items-center gap-1"><Wifi className="w-3 h-3" /> OBS {obsTestResult.obs_version}</span>
-                ) : (
-                  <span className="flex items-center gap-1"><WifiOff className="w-3 h-3" /> {obsTestResult.error}</span>
-                )}
-              </div>
-            )}
           </div>
         )}
       </div>

--- a/frontend/src/components/recordingQueue/RecordingControlDock.jsx
+++ b/frontend/src/components/recordingQueue/RecordingControlDock.jsx
@@ -10,7 +10,7 @@ import { Play, Square, Trash2, Layers, Timer, Settings2 } from "lucide-react";
  *   onAbort: () => void,
  *   onClear: () => void,
  *   disabledStart: boolean,
- *   obsConnected: boolean | null,
+ *   obsConfigured: boolean,
  * }} props
  */
 export default function RecordingControlDock({
@@ -21,7 +21,7 @@ export default function RecordingControlDock({
   onAbort,
   onClear,
   disabledStart,
-  obsConnected,
+  obsConfigured,
 }) {
   const estLabel =
     totalEstimateSec <= 0
@@ -31,8 +31,7 @@ export default function RecordingControlDock({
         : `${Math.max(1, Math.round(totalEstimateSec / 60))} min`;
 
   const statusLabel = batchRecording ? "录制中" : queueLength ? "就绪" : "空闲";
-  const obsDisconnected = obsConnected === false;
-  const startDisabled = disabledStart || obsDisconnected;
+  const startDisabled = disabledStart;
 
   return (
     <div className="flex shrink-0 flex-wrap items-center gap-4 border-t border-cs2-border bg-cs2-bg-page/95 px-4 py-3 backdrop-blur-md sm:gap-4 sm:px-5">
@@ -66,9 +65,6 @@ export default function RecordingControlDock({
             <Play className="h-3.5 w-3.5" />
             开始录制
           </button>
-          {obsDisconnected && !batchRecording && (
-            <span className="text-[9px] font-medium text-red-400/80">OBS 未连接</span>
-          )}
         </div>
         <button
           type="button"

--- a/frontend/src/components/recordingQueue/RecordingStatsStrip.jsx
+++ b/frontend/src/components/recordingQueue/RecordingStatsStrip.jsx
@@ -7,7 +7,7 @@ import { Link } from "react-router-dom";
  *   povSegmentCount: number,
  *   demoCount: number,
  *   queueStatusLabel: "待开始" | "录制中" | "已完成",
- *   obsConnected: boolean | null,
+ *   obsConfigured: boolean,
  *   obsEndpointLabel: string,
  *   obsConfigHasIssues: boolean | null,
  * }} props
@@ -18,7 +18,7 @@ export default function RecordingStatsStrip({
   povSegmentCount,
   demoCount,
   queueStatusLabel,
-  obsConnected,
+  obsConfigured,
   obsEndpointLabel,
   obsConfigHasIssues,
 }) {
@@ -61,16 +61,14 @@ export default function RecordingStatsStrip({
       </span>
       <span
         className={
-          obsConnected === true
+          obsConfigured
             ? "rounded-full border border-emerald-500/25 bg-emerald-500/10 px-2 py-0.5 text-[11px] font-medium leading-none text-emerald-300"
-            : obsConnected === false
-              ? "rounded-full border border-rose-500/30 bg-rose-500/10 px-2 py-0.5 text-[11px] font-medium leading-none text-cs2-rose-on-surface"
-              : "rounded-full border border-cs2-border bg-cs2-bg-hover px-2 py-0.5 text-[11px] font-medium leading-none text-cs2-text-muted"
+            : "rounded-full border border-cs2-border bg-cs2-bg-hover px-2 py-0.5 text-[11px] font-medium leading-none text-cs2-text-muted"
         }
       >
-        {obsConnected === false ? "OBS · 未连接" : `OBS · ${obsEndpointLabel}`}
+        {obsConfigured ? "OBS · 已配置" : "OBS · 未配置"}
       </span>
-      {obsConnected === true && obsConfigHasIssues === true && (
+      {obsConfigured && obsConfigHasIssues === true && (
         <Link to="/obs-config-center">
           <span className="rounded-full border border-amber-500/30 bg-amber-500/10 px-2 py-0.5 text-[11px] font-medium leading-none text-amber-300 hover:bg-amber-500/20 transition-colors">
             OBS 配置待修复

--- a/frontend/src/pages/GuidePage.jsx
+++ b/frontend/src/pages/GuidePage.jsx
@@ -33,10 +33,10 @@ function StatusDot({ ok, loading }) {
 
 const SETUP_ITEMS = [
   {
-    key: "obs_connected",
+    key: "obs_configured",
     required: true,
-    label: "OBS WebSocket 已连通",
-    desc: "录制功能必需。OBS 需开启 WebSocket 服务器，并在配置中心填写端口与密码。",
+    label: "OBS 配置已验证",
+    desc: "录制功能必需。需在 OBS 配置中心点击「配置检查」，成功连接后标记为已验证。录制前会自动检测 OBS 是否运行。",
     to: "/obs-config-center",
     linkLabel: "OBS 配置中心",
   },
@@ -76,7 +76,7 @@ function SetupChecklist() {
   const fetchStatus = async (isBackground = false) => {
     if (!isBackground) setLoading(true);
     try {
-      const { data } = await API.get("/status/setup");
+      const { data } = await API.get("/config/quick-check");
       setStatus(data);
     } catch {
       setStatus(null);
@@ -85,7 +85,7 @@ function SetupChecklist() {
     }
   };
 
-  // OBS 已连接时拉一次配置健康状态（随 setup 刷新同步）
+  // OBS 已配置时拉一次配置健康状态（随 setup 刷新同步）
   const fetchObsConfigHealth = async () => {
     try {
       const st = await getObsConfigStatus();
@@ -98,32 +98,33 @@ function SetupChecklist() {
 
   useEffect(() => {
     fetchStatus(false);
-    timerRef.current = setInterval(() => fetchStatus(true), 8000);
+    // quick-check 不连 OBS 很快，保留轮询以反映配置变化
+    timerRef.current = setInterval(() => fetchStatus(true), 15000);
     return () => clearInterval(timerRef.current);
   }, []);
 
-  // OBS 连通状态变化时同步拉配置健康
+  // OBS 配置状态变化时同步拉配置健康
   useEffect(() => {
-    if (status?.obs_connected) {
+    if (status?.obs_configured) {
       void fetchObsConfigHealth();
     } else {
       setObsConfigHasIssues(null);
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [status?.obs_connected]);
+  }, [status?.obs_configured]);
 
   const handleRefresh = async () => {
     setRefreshing(true);
     try {
       await fetchStatus(true);
-      if (status?.obs_connected) await fetchObsConfigHealth();
+      if (status?.obs_configured) await fetchObsConfigHealth();
     } finally {
       setRefreshing(false);
     }
   };
 
   const allRequired =
-    status?.obs_connected && status?.cs2_path_ok;
+    status?.obs_configured && status?.cs2_path_ok;
 
   return (
     <section>
@@ -151,7 +152,7 @@ function SetupChecklist() {
       <div className="grid gap-2 sm:grid-cols-2">
         {SETUP_ITEMS.map(({ key, required, label, desc, to, linkLabel }) => {
           const ok = status?.[key] ?? false;
-          const isObs = key === "obs_connected";
+          const isObs = key === "obs_configured";
           return (
             <div
               key={key}

--- a/frontend/src/pages/ObsConfigCenterPage.jsx
+++ b/frontend/src/pages/ObsConfigCenterPage.jsx
@@ -1,6 +1,6 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import API from "../api/api";
-import { AlertTriangle, CheckCircle2, Loader2, RefreshCw, RotateCcw, Wifi, WifiOff } from "lucide-react";
+import { AlertTriangle, CheckCircle2, Loader2, RefreshCw, RotateCcw, Wifi, WifiOff, Monitor } from "lucide-react";
 import PageContainer from "../components/PageContainer";
 import { useAppShell } from "../context/AppShellContext";
 import { calibrateObs, getObsConfigStatus } from "../api/obsConfigCenter";
@@ -21,13 +21,29 @@ export default function ObsConfigCenterPage() {
   const [status, setStatus] = useState(null);
   const [calibrating, setCalibrating] = useState(false);
   const [calibrateResult, setCalibrateResult] = useState(null);
-  const [statusRefreshing, setStatusRefreshing] = useState(false);
+  const [checking, setChecking] = useState(false);
+  const [checkResult, setCheckResult] = useState(null);
   const [errorText, setErrorText] = useState("");
-  const [obsTesting, setObsTesting] = useState(false);
-  const [obsTestResult, setObsTestResult] = useState(null);
+  const [detectingObs, setDetectingObs] = useState(false);
+  const [statusRefreshing, setStatusRefreshing] = useState(false);
 
   const obsConfigRef = useRef(obsConfig);
   obsConfigRef.current = obsConfig;
+
+  const detectObsPath = async () => {
+    setDetectingObs(true);
+    try {
+      const { data } = await API.post("/config/detect-obs");
+      if (data?.obs_path) {
+        setObsConfig({ ...obsConfigRef.current, obs_path: data.obs_path });
+        await persistObsConfig?.();
+      }
+    } catch (e) {
+      setErrorText(e.response?.data?.detail || e.message || "自动探测失败");
+    } finally {
+      setDetectingObs(false);
+    }
+  };
 
   const fetchStatus = useCallback(async () => {
     const st = await getObsConfigStatus();
@@ -43,30 +59,22 @@ export default function ObsConfigCenterPage() {
     }
   }, [fetchStatus]);
 
-  useEffect(() => {
-    void refreshSilent();
-  }, [refreshSilent]);
 
-  const testObsConnection = async () => {
-    setObsTesting(true);
-    setObsTestResult(null);
+  const handleConfigCheck = async () => {
+    setChecking(true);
+    setCheckResult(null);
+    setErrorText("");
     try {
-      const { data } = await API.post("/obs/test", obsConfigRef.current);
-      if (data?.ok) {
+      const { data } = await API.post("/obs/config-check", obsConfigRef.current);
+      setCheckResult(data);
+      if (data.connected) {
         await persistObsConfig?.();
-        await refreshSilent();
-        setStatus((prev) => {
-          if (!prev) return prev;
-          const ver = data.obs_version || prev.obs_version;
-          return { ...prev, obs_connected: true, ...(ver ? { obs_version: ver } : {}) };
-        });
-      } else {
-        setObsTestResult({ ok: false, error: data?.error || "连接失败" });
+        await fetchStatus();
       }
     } catch (e) {
-      setObsTestResult({ ok: false, error: e?.response?.data?.detail || e.message });
+      setErrorText(e.response?.data?.detail || e.message || "配置检查失败");
     } finally {
-      setObsTesting(false);
+      setChecking(false);
     }
   };
 
@@ -123,82 +131,132 @@ export default function ObsConfigCenterPage() {
           </div>
         ) : null}
 
-        {/* OBS WebSocket 连接 */}
+        {/* OBS 程序设置 */}
         <section className="mt-4 rounded-xl border border-cs2-border bg-cs2-bg-card p-5 shadow-sm">
-          <div className="flex flex-wrap items-start justify-between gap-3">
-            <div className="min-w-0 flex-1">
-              <div className="text-sm font-semibold text-cs2-text-primary">OBS WebSocket 连接</div>
-              <p className="mt-1 text-[12px] leading-relaxed text-cs2-text-muted">
-                与 OBS「工具 → WebSocket 服务器设置」中的主机、端口、密码一致；保存配置后录制均使用该连接。
-              </p>
+          <div className="flex items-center justify-between gap-3">
+            <h2 className="text-sm font-semibold text-cs2-text-primary">OBS 程序设置</h2>
+            <button
+              type="button"
+              onClick={() => void handleConfigCheck()}
+              disabled={checking}
+              title="配置检查"
+              className="shrink-0 flex items-center gap-1.5 rounded-lg border border-cs2-border bg-cs2-bg-input px-4 py-2 text-[12px] font-semibold text-cs2-text-primary transition-colors hover:bg-cs2-bg-hover disabled:opacity-50"
+            >
+              {checking ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <CheckCircle2 className="h-3.5 w-3.5" />}
+              {checking ? "检查中" : "配置检查"}
+            </button>
+          </div>
+          <p className="mt-2 text-[12px] leading-relaxed text-cs2-text-secondary">
+            配置 OBS 启动路径与 WebSocket 连接信息，用于录制前自动拉起 OBS 并控制回放。
+          </p>
+
+          {/* 启动配置 */}
+          <div className="mt-4">
+            <div className="flex items-center justify-between">
+              <div className="text-[13px] font-semibold text-cs2-text-primary">启动配置</div>
+              {checkResult != null && (
+                <span className={`inline-flex items-center gap-1.5 font-mono text-[12px] ${checkResult.path_ok ? "text-cs2-text-success" : "text-cs2-amber-on-surface"}`}>
+                  <CheckCircle2 className="h-3.5 w-3.5 shrink-0" />
+                  路径正确
+                </span>
+              )}
             </div>
-            {status != null ? (
-              <div className="shrink-0 text-right">
-                {status.obs_connected ? (
+            <p className="mt-1 text-[12px] leading-relaxed text-cs2-text-secondary">
+              填写 OBS 可执行文件的完整路径，用于录制前自动启动 OBS。
+            </p>
+            <div className="mt-2 flex gap-2">
+              <input
+                type="text"
+                value={obsConfig.obs_path ?? ""}
+                onChange={(e) => setObsConfig({ ...obsConfig, obs_path: e.target.value })}
+                placeholder="例如 C:\Program Files\obs-studio\bin\64bit\obs64.exe"
+                className="flex-1 rounded-md border border-cs2-border bg-cs2-bg-input px-3 py-2 font-mono text-xs text-cs2-text-primary transition-colors placeholder:text-cs2-text-muted/80 focus:border-cs2-accent/50 focus:outline-none"
+              />
+              <button
+                type="button"
+                onClick={() => void detectObsPath()}
+                disabled={detectingObs}
+                title="自动探测 OBS 安装路径"
+                className="shrink-0 rounded-md border border-cs2-border bg-cs2-bg-input px-3 py-2 text-[11px] font-semibold text-cs2-text-muted transition-colors hover:bg-cs2-bg-hover hover:text-cs2-text-primary disabled:opacity-50"
+              >
+                {detectingObs ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Monitor className="h-3.5 w-3.5" />}
+              </button>
+            </div>
+          </div>
+
+          {/* 连接配置 */}
+          <div className="mt-4">
+            <div className="flex items-center justify-between">
+              <div className="text-[13px] font-semibold text-cs2-text-primary">连接配置</div>
+              {checkResult != null ? (
+                checkResult.connected ? (
                   <span className="inline-flex items-center gap-1.5 font-mono text-[12px] text-cs2-text-success">
                     <Wifi className="h-3.5 w-3.5 shrink-0" />
-                    已连接{status.obs_version ? ` · ${status.obs_version}` : ""}
+                    连接正确{checkResult.obs_version ? ` · ${checkResult.obs_version}` : ""}
                   </span>
                 ) : (
                   <span className="inline-flex items-center gap-1.5 font-mono text-[12px] text-cs2-amber-on-surface">
                     <WifiOff className="h-3.5 w-3.5 shrink-0" />
-                    未连接
+                    连接失败
                   </span>
-                )}
+                )
+              ) : status != null ? (
+                status.obs_connected ? (
+                  <span className="inline-flex items-center gap-1.5 font-mono text-[12px] text-cs2-text-success">
+                    <Wifi className="h-3.5 w-3.5 shrink-0" />
+                    已连接{status.obs_version ? ` · ${status.obs_version}` : ""}
+                  </span>
+                ) : null
+              ) : null}
+            </div>
+            <p className="mt-1 text-[12px] leading-relaxed text-cs2-text-secondary">
+              与 OBS 菜单栏「工具 → WebSocket 服务器设置」中的主机、端口、密码保持一致。
+            </p>
+            <div className="mt-2 grid gap-3 sm:grid-cols-3">
+              <div>
+                <label className="mb-1.5 block text-[12px] font-semibold uppercase tracking-wider text-cs2-text-muted">
+                  主机地址
+                </label>
+                <input
+                  type="text"
+                  value={obsConfig.host ?? ""}
+                  onChange={(e) => setObsConfig({ ...obsConfig, host: e.target.value })}
+                  className="w-full rounded-md border border-cs2-border bg-cs2-bg-input px-3 py-2 font-mono text-xs text-cs2-text-primary transition-colors focus:border-cs2-accent/50 focus:outline-none"
+                />
               </div>
-            ) : null}
-          </div>
-          <div className="mt-3 grid gap-3 sm:grid-cols-3">
-            <div>
-              <label className="mb-1.5 block text-[12px] font-semibold uppercase tracking-wider text-cs2-text-muted">
-                主机地址
-              </label>
-              <input
-                type="text"
-                value={obsConfig.host ?? ""}
-                onChange={(e) => setObsConfig({ ...obsConfig, host: e.target.value })}
-                className="w-full rounded-md border border-cs2-border bg-cs2-bg-input px-3 py-2 font-mono text-xs text-cs2-text-primary transition-colors focus:border-cs2-accent/50 focus:outline-none"
-              />
-            </div>
-            <div>
-              <label className="mb-1.5 block text-[12px] font-semibold uppercase tracking-wider text-cs2-text-muted">
-                端口
-              </label>
-              <input
-                type="number"
-                value={obsConfig.port ?? 4455}
-                onChange={(e) => setObsConfig({ ...obsConfig, port: Number(e.target.value) })}
-                className="w-full rounded-md border border-cs2-border bg-cs2-bg-input px-3 py-2 font-mono text-xs text-cs2-text-primary transition-colors focus:border-cs2-accent/50 focus:outline-none"
-              />
-            </div>
-            <div>
-              <label className="mb-1.5 block text-[12px] font-semibold uppercase tracking-wider text-cs2-text-muted">
-                密码
-              </label>
-              <input
-                type="password"
-                value={obsConfig.password ?? ""}
-                placeholder={obsPasswordPlaceholder}
-                onChange={(e) => setObsConfig({ ...obsConfig, password: e.target.value })}
-                onFocus={() => handleObsPasswordFocus?.()}
-                onBlur={() => handleObsPasswordBlur?.()}
-                autoComplete="new-password"
-                className="w-full rounded-md border border-cs2-border bg-cs2-bg-input px-3 py-2 font-mono text-xs text-cs2-text-primary transition-colors placeholder:text-cs2-text-muted/80 focus:border-cs2-accent/50 focus:outline-none"
-              />
+              <div>
+                <label className="mb-1.5 block text-[12px] font-semibold uppercase tracking-wider text-cs2-text-muted">
+                  端口
+                </label>
+                <input
+                  type="number"
+                  value={obsConfig.port ?? 4455}
+                  onChange={(e) => setObsConfig({ ...obsConfig, port: Number(e.target.value) })}
+                  className="w-full rounded-md border border-cs2-border bg-cs2-bg-input px-3 py-2 font-mono text-xs text-cs2-text-primary transition-colors focus:border-cs2-accent/50 focus:outline-none"
+                />
+              </div>
+              <div>
+                <label className="mb-1.5 block text-[12px] font-semibold uppercase tracking-wider text-cs2-text-muted">
+                  密码
+                </label>
+                <input
+                  type="password"
+                  value={obsConfig.password ?? ""}
+                  placeholder={obsPasswordPlaceholder}
+                  onChange={(e) => setObsConfig({ ...obsConfig, password: e.target.value })}
+                  onFocus={() => handleObsPasswordFocus?.()}
+                  onBlur={() => handleObsPasswordBlur?.()}
+                  autoComplete="new-password"
+                  className="w-full rounded-md border border-cs2-border bg-cs2-bg-input px-3 py-2 font-mono text-xs text-cs2-text-primary transition-colors placeholder:text-cs2-text-muted/80 focus:border-cs2-accent/50 focus:outline-none"
+                />
+              </div>
             </div>
           </div>
-          <button
-            type="button"
-            onClick={() => void testObsConnection()}
-            disabled={obsTesting}
-            className="mt-3 w-full rounded-lg border border-cs2-border bg-cs2-bg-input py-2.5 text-[12px] font-semibold text-cs2-text-primary transition-colors hover:bg-cs2-bg-hover disabled:opacity-50 sm:w-auto sm:px-6"
-          >
-            {obsTesting ? "测试中…" : "测试连接"}
-          </button>
-          {obsTestResult && !obsTestResult.ok ? (
+
+          {checkResult?.error && !checkResult.path_ok && !checkResult.connected ? (
             <div className="mt-3 rounded-lg bg-cs2-rose-surface px-3 py-2 font-mono text-[12px] text-cs2-rose-on-surface">
               <span className="flex items-center gap-2">
-                <WifiOff className="h-3.5 w-3.5 shrink-0" /> {obsTestResult.error}
+                <WifiOff className="h-3.5 w-3.5 shrink-0" /> {checkResult.error}
               </span>
             </div>
           ) : null}

--- a/frontend/src/pages/RecordingQueuePage.jsx
+++ b/frontend/src/pages/RecordingQueuePage.jsx
@@ -1,7 +1,5 @@
 import { useMemo, useState, useEffect, useCallback, useRef } from "react";
 import API from "../api/api";
-import { getObsConfigStatus } from "../api/obsConfigCenter";
-import { obsConfigHasIssues } from "../utils/obsConfigHealth";
 import { useAppShell } from "../context/AppShellContext";
 import { useRecordingQueue } from "../stores/recordingQueueStore";
 import {
@@ -25,6 +23,22 @@ export default function RecordingQueuePage() {
   const [selectedId, setSelectedId] = useState(null);
   const [dragSourceIndex, setDragSourceIndex] = useState(null);
   const [dropTargetIndex, setDropTargetIndex] = useState(null);
+
+  // OBS 配置状态：与首页 /api/config/quick-check 一致，后端判断 host + password + port > 0
+  const [obsConfigured, setObsConfigured] = useState(false);
+  const [obsConfigHasIssues, setObsConfigHasIssues] = useState(/** @type {boolean | null} */ (null));
+
+  useEffect(() => {
+    let cancelled = false;
+    API.get("/config/quick-check").then(({ data }) => {
+      if (cancelled) return;
+      setObsConfigured(!!data?.obs_configured);
+    }).catch(() => {
+      if (cancelled) return;
+      setObsConfigured(false);
+    });
+    return () => { cancelled = true; };
+  }, []);
 
   useEffect(() => {
     if (queue.length === 0) {
@@ -60,44 +74,6 @@ export default function RecordingQueuePage() {
       ? "待开始"
       : "已完成";
   const obsEndpointLabel = `${s.obsConfig?.host || "localhost"}:${s.obsConfig?.port ?? 4455}`;
-
-  const [obsConnected, setObsConnected] = useState(/** @type {boolean | null} */ (null));
-  const [obsConfigHasIssues, setObsConfigHasIssues] = useState(/** @type {boolean | null} */ (null));
-  const obsProbeGen = useRef(0);
-  useEffect(() => {
-    setObsConnected(null);
-    setObsConfigHasIssues(null);
-    const gen = ++obsProbeGen.current;
-    let cancelled = false;
-    const run = async () => {
-      try {
-        const { data } = await API.post("/obs/test", s.obsConfig);
-        if (cancelled || gen !== obsProbeGen.current) return;
-        setObsConnected(Boolean(data?.ok));
-      } catch {
-        if (cancelled || gen !== obsProbeGen.current) return;
-        setObsConnected(false);
-      }
-    };
-    void run();
-    const id = setInterval(run, 45_000);
-    return () => {
-      cancelled = true;
-      clearInterval(id);
-    };
-  }, [s.obsConfig?.host, s.obsConfig?.port, s.obsConfig?.password]);
-
-  // OBS 连上后拉一次配置健康状态（不循环轮询，避免频繁打扰 OBS）
-  useEffect(() => {
-    if (obsConnected !== true) { setObsConfigHasIssues(null); return; }
-    let cancelled = false;
-    getObsConfigStatus().then((st) => {
-      if (cancelled) return;
-      if (!st?.obs_connected) { setObsConfigHasIssues(null); return; }
-      setObsConfigHasIssues(obsConfigHasIssues(st));
-    }).catch(() => { if (!cancelled) setObsConfigHasIssues(null); });
-    return () => { cancelled = true; };
-  }, [obsConnected]);
 
   const canReorder = queue.length > 1 && !s.batchRecording;
 
@@ -152,7 +128,7 @@ export default function RecordingQueuePage() {
           povSegmentCount={povN}
           demoCount={demoN}
           queueStatusLabel={queueStatusLabel}
-          obsConnected={obsConnected}
+          obsConfigured={obsConfigured}
           obsEndpointLabel={obsEndpointLabel}
           obsConfigHasIssues={obsConfigHasIssues}
         />
@@ -227,7 +203,7 @@ export default function RecordingQueuePage() {
         onAbort={s.handleAbortBatchRecording}
         onClear={handleClear}
         disabledStart={queue.length === 0 || s.batchRecording}
-        obsConnected={obsConnected}
+        obsConfigured={obsConfigured}
       />
     </div>
     </PageContainer>


### PR DESCRIPTION
 ## PR改动

与 #39 提到的，进行如下改进：
  - **OBS 配置验证持久化**：新增 `obs_config_verified` 字段到 `OBSConfig`
  模型，当配置中心「配置检查」或录制前检测通过时自动标记并写入配置文件。首页引导页与录制队列页据此显示 OBS
  状态（已验证/未验证），不再每次探测 WebSocket 连接。
  - **开始录制自动拉起 OBS**：点击"开始录制"时，若 OBS 进程未运行则自动启动（轮询等待进程出现 + 1s），再进行 WebSocket
  连通性检测，通过后进入录制预热流程。
  - **配置中心改造**：OBS 配置中心改为「配置检查」按钮（先拉起 OBS → 测 WebSocket），移除侧边栏冗余的「测试连接」按钮。

  ## 修改内容

  | 端点 / 文件 | 变更 |
  |---|---|
  | `POST /api/obs/config-check` | 连接成功后标记 `obs_config_verified = True`，改为轮询等待进程启动 |
  | `POST /api/obs/is-running`（新增） | 检查 OBS 进程是否运行（tasklist） |
  | `POST /api/obs/launch`（新增） | 拉起 OBS 进程，设置 cwd 避免 locale 错误 |
  | `GET /api/config/quick-check` | 返回 `obs_config_verified` |
  | `OBSConfig` 模型 | 新增 `obs_config_verified: bool = False` |

  ## 影响逻辑

  - OBS 未运行时，进入配置中心点击「配置检查」→ OBS 自动拉起 → 连接成功 → 首页显示"OBS 配置已验证"
  - OBS 未配置时，首页显示"OBS 配置未验证"
  - OBS 未运行，点击"开始录制" → 自动拉起 OBS → WebSocket 检测通过 → 进入预热弹窗
  - 侧边栏不再显示"测试连接"按钮
  - 录制队列页右上角显示 OBS"已配置/未配置"，不触发 45s 轮询

前端改动

<img width="1549" height="493" alt="image" src="https://github.com/user-attachments/assets/37ea8453-9318-4ccb-87c5-36d9c9bb466a" />

<img width="1374" height="437" alt="image" src="https://github.com/user-attachments/assets/246f8679-d3d8-4ca9-bb5b-69121f9335c4" />

由于如果没有拉起，点击开始录制时会自动拉起，所以只要验证过一次就行
<img width="1370" height="819" alt="image" src="https://github.com/user-attachments/assets/9ff63744-ce52-4e84-ae10-36a97fd687eb" />
