### PR TITLE
chore: 精简后端打包

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -11,6 +11,5 @@ openai>=1.40.0
 pydantic>=2.9.0
 aiosqlite>=0.20.0
 watchdog>=4.0.0
-matplotlib>=3.8.0
 packaging>=24.0
 httpx>=0.27.0

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -49,7 +49,14 @@
           "**/*",
           "!**/__pycache__",
           "!**/*.pyc",
-          "!**/.pytest_cache"
+          "!**/.pytest_cache",
+          "!dist/**",
+          "!logs/**",
+          "!scripts/**",
+          "!tests/**",
+          "!*.db",
+          "!*.exe",
+          "!debug_*.py"
         ]
       },
       {

--- a/frontend/scripts/copy-python-for-bundle.mjs
+++ b/frontend/scripts/copy-python-for-bundle.mjs
@@ -44,6 +44,16 @@ function shouldSkip(rel) {
   if (lower.includes("/__pycache__/") || lower.endsWith("/__pycache__")) return true;
   if (lower.includes("/lib/test/") || lower.endsWith("/lib/test")) return true;
   if (lower.includes("/lib/tkinter/test/")) return true;
+  // Exclude pip and build tools — not needed at runtime
+  if (lower.includes("/lib/site-packages/pip/") || lower.endsWith("/lib/site-packages/pip")) return true;
+  if (lower.includes("/lib/site-packages/pip-") && lower.includes(".dist-info")) return true;
+  if (lower.includes("/lib/site-packages/setuptools/") || lower.endsWith("/lib/site-packages/setuptools")) return true;
+  if (lower.includes("/lib/site-packages/setuptools-") && lower.includes(".dist-info")) return true;
+  if (lower.includes("/lib/site-packages/wheel/") || lower.endsWith("/lib/site-packages/wheel")) return true;
+  if (lower.includes("/lib/site-packages/wheel-") && lower.includes(".dist-info")) return true;
+  if (lower.includes("/lib/site-packages/pkg_resources/") || lower.endsWith("/lib/site-packages/pkg_resources")) return true;
+  if (lower.includes("/lib/site-packages/pkg_resources-") && lower.includes(".dist-info")) return true;
+  if (lower.startsWith("scripts/pip") || lower.includes("/scripts/pip")) return true;
   return false;
 }
 

--- a/package_portable.ps1
+++ b/package_portable.ps1
@@ -125,6 +125,8 @@ function Install-BackendRequirements {
     if ($LASTEXITCODE -ne 0) { throw "pip upgrade failed (exit $LASTEXITCODE)" }
     & $PythonExe -m pip install -r $RequirementsPath
     if ($LASTEXITCODE -ne 0) { throw "pip install -r requirements.txt failed (exit $LASTEXITCODE)" }
+    Write-Step "Remove pip / setuptools / wheel (not needed at runtime)"
+    & $PythonExe -m pip uninstall -y pip setuptools wheel
 }
 
 function Bundle-PythonInto {


### PR DESCRIPTION
 ## Changes
  | 改动 | 效果 |
  |------|------|
  | `package.json` backend extraResources filter | 排除
  `dist/`、`logs/`、`scripts/`、`tests/`、`*.db`、`*.exe`、`debug_*.py`，保留 `app/` + `assets/` |
  | `backend/requirements.txt` | 移除未使用的 `matplotlib` |
  | `package_portable.ps1` + `copy-python-for-bundle.mjs` | 打包后卸载 / 跳过 pip、setuptools、wheel |

  ## Size impact (approx)
  - 本 PR 可省 ~13MB（pip 工具链），~40MB （matplotlib）， backend 额外排除 `dist/logs/scripts/tests` 等约数 MB