### PR TITLE
fix: OBS config center path indicator color and connection retry

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1139,13 +1139,23 @@ def obs_config_check(payload: OBSConfig | None = Body(default=None)):
         logger.info("[OBS config-check] No obs_path configured, skipping launch")
         return {"path_ok": False, "connected": False, "error": "请先配置 OBS 路径，再点击配置检查"}
 
-    # 2) 测试 WebSocket 连接
+    # 2) 测试 WebSocket 连接 — 15s 内每 1s 重试一次
     try:
         from .obs_director import OBSDirector
         director = OBSDirector(obs_use, cfg.cs2_path)
-        result = director.test_obs_connection()
-        connected = bool(result.get("ok"))
-        obs_version = result.get("obs_version")
+
+        connected = False
+        obs_version = None
+        for _attempt in range(15):
+            result = director.test_obs_connection()
+            if result.get("ok"):
+                connected = True
+                obs_version = result.get("obs_version")
+                break
+            _time.sleep(1)
+        else:
+            logger.warning("[OBS config-check] WebSocket connection failed after 15 retries")
+
         if connected:
             _normalize_obs_path_auto_detect(cfg)
             cfg.obs.obs_config_verified = True

--- a/frontend/src/pages/ObsConfigCenterPage.jsx
+++ b/frontend/src/pages/ObsConfigCenterPage.jsx
@@ -160,10 +160,17 @@ export default function ObsConfigCenterPage() {
             <div className="flex items-center justify-between">
               <div className="text-[13px] font-semibold text-cs2-text-primary">启动配置</div>
               {checkResult != null && (
-                <span className={`inline-flex items-center gap-1.5 font-mono text-[12px] ${checkResult.path_ok ? "text-cs2-text-success" : "text-cs2-amber-on-surface"}`}>
-                  <CheckCircle2 className="h-3.5 w-3.5 shrink-0" />
-                  路径正确
-                </span>
+                checkResult.path_ok ? (
+                  <span className="inline-flex items-center gap-1.5 font-mono text-[12px] text-cs2-text-success">
+                    <CheckCircle2 className="h-3.5 w-3.5 shrink-0" />
+                    路径正确
+                  </span>
+                ) : (
+                  <span className="inline-flex items-center gap-1.5 font-mono text-[12px] text-cs2-amber-on-surface">
+                    <AlertTriangle className="h-3.5 w-3.5 shrink-0" />
+                    路径错误
+                  </span>
+                )
               )}
             </div>
             <p className="mt-1 text-[12px] leading-relaxed text-cs2-text-secondary">
@@ -202,7 +209,7 @@ export default function ObsConfigCenterPage() {
                 checkResult.connected ? (
                   <span className="inline-flex items-center gap-1.5 font-mono text-[12px] text-cs2-text-success">
                     <Wifi className="h-3.5 w-3.5 shrink-0" />
-                    连接正确{checkResult.obs_version ? ` · ${checkResult.obs_version}` : ""}
+                    连接正确
                   </span>
                 ) : (
                   <span className="inline-flex items-center gap-1.5 font-mono text-[12px] text-cs2-amber-on-surface">
@@ -210,13 +217,6 @@ export default function ObsConfigCenterPage() {
                     连接失败
                   </span>
                 )
-              ) : status != null ? (
-                status.obs_connected ? (
-                  <span className="inline-flex items-center gap-1.5 font-mono text-[12px] text-cs2-text-success">
-                    <Wifi className="h-3.5 w-3.5 shrink-0" />
-                    已连接{status.obs_version ? ` · ${status.obs_version}` : ""}
-                  </span>
-                ) : null
               ) : null}
             </div>
             <p className="mt-1 text-[12px] leading-relaxed text-cs2-text-secondary">


### PR DESCRIPTION
## Summary

  - OBS 路径检查失败时显示警告图标和"路径错误"，修复之前始终显示成功的问题
  - 配置检查时 WebSocket 连接增加 15s 重试（每秒一次），给 OBS 留出启动时间
  - 移除中间态连接状态和版本信息展示

原来的问题：
<img width="1366" height="507" alt="Screenshot 2026-05-24 112844" src="https://github.com/user-attachments/assets/67c2c429-1e29-4c6f-8d67-e2eb17444250" />

现在：
<img width="1386" height="526" alt="image" src="https://github.com/user-attachments/assets/9c02ce43-3fdb-48b3-9030-181fbdb2912d" />
<img width="1360" height="519" alt="image" src="https://github.com/user-attachments/assets/803b5002-68b5-4ec1-8af5-72ce4d3a119a" />
