### PR TITLE
feat: Demo 库文件删除 + 布局优化

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1898,6 +1898,32 @@ async def delete_demo(
     return {"status": "deleted", "demo_id": demo_id}
 
 
+@app.post("/api/demos/{demo_id}/delete-file")
+async def delete_demo_file(demo_id: int):
+    """从磁盘删除 .dem 文件（如有同名 .zip 也一并删除），同时删除库内记录。"""
+    demo = await demo_db.get_demo_by_id(demo_id)
+    if not demo:
+        raise HTTPException(404, f"Demo not found: {demo_id}")
+    disk_path = str(demo["path"])
+    import os as _os
+    deleted_files: list[str] = []
+    errors: list[str] = []
+    for target in (disk_path, disk_path.rsplit(".", 1)[0] + ".zip" if "." in _os.path.basename(disk_path) else None):
+        if target is None:
+            continue
+        try:
+            _os.remove(target)
+            deleted_files.append(target)
+        except FileNotFoundError:
+            pass
+        except OSError as e:
+            errors.append(f"{target}: {e}")
+    # 无论文件删除成功与否，都删除库内记录
+    await demo_db.delete_demo(demo_id, rescan="skip")
+    await demo_library_hub.notify("deleted")
+    return {"status": "deleted", "demo_id": demo_id, "deleted_files": deleted_files, "errors": errors}
+
+
 class BatchIngestBody(BaseModel):
     demo_ids: list[int] = Field(..., min_length=1, max_length=200)
 

--- a/frontend/electron-main.cjs
+++ b/frontend/electron-main.cjs
@@ -49,13 +49,13 @@ function resolveWindowIconPath() {
 
 function createWindow() {
   const { width, height } = screen.getPrimaryDisplay().workAreaSize;
-  const initWidth = Math.min(1600, Math.floor(width * 0.8));
+  const initWidth = Math.min(1700, Math.floor(width * 0.8));
   const initHeight = Math.min(900, Math.floor(height * 0.8));
 
   mainWindow = new BrowserWindow({
     width: initWidth,
     height: initHeight,
-    minWidth: 1440,
+    minWidth: 1540,
     minHeight: 900,
     frame: false, // 移除原生菜单和标题栏
     titleBarStyle: 'hidden',

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -190,7 +190,7 @@ export default function App() {
   });
   const [libraryJumpDraft, setLibraryJumpDraft] = useState("");
   /** Demo 库列表每页条数（与 GET /demos limit 一致） */
-  const [libraryPageSize, setLibraryPageSize] = useState(10);
+  const [libraryPageSize, setLibraryPageSize] = useState(12);
   const libraryPageSizeEffectSkipRef = useRef(false);
   const [libraryBatchModalOpen, setLibraryBatchModalOpen] = useState(false);
   const [llmKeySavedOnServer, setLlmKeySavedOnServer] = useState(false);
@@ -524,6 +524,20 @@ export default function App() {
         await refreshDemoLibrary(libraryPage, { manageLoading: false });
       } catch (e) {
         setProgressText(`删除失败: ${e.response?.data?.detail || e.message}`);
+      }
+    },
+    [refreshDemoLibrary, libraryPage]
+  );
+
+  const handleDeleteDemoFile = useCallback(
+    async (id) => {
+      try {
+        await API.post(`/demos/${id}/delete-file`);
+        setLibraryDeletePrompt(null);
+        setProgressText("已从磁盘删除 .dem 文件（如有同名 .zip 也一并删除）。");
+        await refreshDemoLibrary(libraryPage, { manageLoading: false });
+      } catch (e) {
+        setProgressText(`删除文件失败: ${e.response?.data?.detail || e.message}`);
       }
     },
     [refreshDemoLibrary, libraryPage]
@@ -2315,6 +2329,7 @@ export default function App() {
     hasLibraryAdvancedFilters,
     handleLoadDemoFromLibrary,
     handleDeleteDemo,
+    handleDeleteDemoFile,
     handleLibraryBatchDelete,
     setProgressText,
     handleSaveLibraryRename,

--- a/frontend/src/components/MatchCard.jsx
+++ b/frontend/src/components/MatchCard.jsx
@@ -418,7 +418,7 @@ export default function MatchCard({
       <div className="grid grid-cols-2 border-y border-cs2-border bg-cs2-bg-input/30 group/roster w-full transition-colors hover:bg-cs2-bg-hover">
         <div className="relative border-r border-cs2-border px-3 py-1">
           <div className="text-[10px] font-bold uppercase tracking-wider text-cs2-text-muted">{matchMeta.team_a_name || "Team A"}</div>
-          <div className="flex flex-wrap gap-1">
+          <div className="h-[50px] overflow-y-auto flex flex-wrap gap-1 scrollbar-hover">
             {teamA.length > 0 ? teamA.slice(0, 5).map((p, i) => (
               <span key={i} className={`relative flex items-center gap-0.5 text-[10px] ${isHighlighted(p.name) ? 'font-bold text-cs2-accent underline underline-offset-2' : 'text-cs2-text-secondary'}`} title={p.name}>
                 {p.name?.slice(0, 8)}{p.name?.length > 8 ? '..' : ''}
@@ -430,7 +430,7 @@ export default function MatchCard({
         </div>
         <div className="px-3 py-1">
           <div className="mb-1 text-[10px] font-bold uppercase tracking-wider text-cs2-text-muted">{matchMeta.team_b_name || "Team B"}</div>
-          <div className="flex flex-wrap gap-1">
+          <div className="h-[50px] overflow-y-auto flex flex-wrap gap-1 scrollbar-hover">
             {teamB.length > 0 ? teamB.slice(0, 5).map((p, i) => (
               <span key={i} className={`relative flex items-center gap-0.5 text-[10px] ${isHighlighted(p.name) ? 'font-bold text-cs2-accent underline underline-offset-2' : 'text-cs2-text-secondary'}`} title={p.name}>
                 {p.name?.slice(0, 8)}{p.name?.length > 8 ? '..' : ''}

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -121,7 +121,7 @@ export default function Sidebar({
   const isLocal = llmBaseUrlLooksLocal(llmConfig.base_url);
 
   return (
-    <aside className="w-72 bg-cs2-bg-sidebar border-r border-cs2-border flex flex-col overflow-y-auto shrink-0">
+    <aside className="w-60 bg-cs2-bg-sidebar border-r border-cs2-border flex flex-col overflow-y-auto shrink-0">
       {/* Logo */}
       <div className="px-4 py-5 border-b border-cs2-border">
         <div className="flex items-center gap-2">

--- a/frontend/src/components/demoLibrary/DemoPagination.jsx
+++ b/frontend/src/components/demoLibrary/DemoPagination.jsx
@@ -1,6 +1,6 @@
 import { ChevronLeft, ChevronRight } from "lucide-react";
 
-const PAGE_SIZE_OPTIONS = [10, 20, 50, 100];
+const PAGE_SIZE_OPTIONS = [12, 24, 48, 96];
 
 export default function DemoPagination({
   libraryPage,

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -47,9 +47,9 @@
   --cs2-surface-3: #333333;
 
   /* 滚动条 */
-  --cs2-scrollbar-track: #111111;
-  --cs2-scrollbar-thumb: #333333;
-  --cs2-scrollbar-thumb-hover: #555555;
+  --cs2-scrollbar-track: #1a1a1a;
+  --cs2-scrollbar-thumb: #555555;
+  --cs2-scrollbar-thumb-hover: #777777;
 
   /* 状态色 surface（badge/tag 背景） */
   --cs2-rose-surface: rgba(248,113,113,0.12);
@@ -246,6 +246,16 @@ html {
   border-radius: 3px;
 }
 ::-webkit-scrollbar-thumb:hover {
+  background: var(--cs2-scrollbar-thumb-hover);
+}
+
+.scrollbar-hover::-webkit-scrollbar-thumb {
+  background: transparent;
+}
+.scrollbar-hover:hover::-webkit-scrollbar-thumb {
+  background: var(--cs2-scrollbar-thumb);
+}
+.scrollbar-hover:hover::-webkit-scrollbar-thumb:hover {
   background: var(--cs2-scrollbar-thumb-hover);
 }
 

--- a/frontend/src/pages/DemoLibraryPage.jsx
+++ b/frontend/src/pages/DemoLibraryPage.jsx
@@ -380,6 +380,24 @@ export default function DemoLibraryPage() {
                   之后目录监听与手动扫描都会跳过该路径；仅改文件名或移动文件可视为新路径再入库。
                 </span>
               </button>
+              <button
+                type="button"
+                className="rounded border border-red-500/40 bg-red-500/10 px-3 py-2 text-left text-[11px] leading-snug text-red-400 hover:bg-red-500/20"
+                onClick={() => {
+                  const p = s.libraryDeletePrompt;
+                  const row = s.demoLibraryItems.find((it) => it.id === p.id);
+                  const base = (row?.filename || p.label || "").replace(/\.\w+$/, "");
+                  const files = [`${base}.dem`, `${base}.zip`];
+                  if (window.confirm(`确定要删除以下文件？\n\n${files.join("\n")}\n\n此操作不可恢复。`)) {
+                    void s.handleDeleteDemoFile(p.id);
+                  }
+                }}
+              >
+                从磁盘删除文件
+                <span className="mt-0.5 block text-[11px] font-normal text-red-300/60">
+                  永久删除 .dem 及同名 .zip 文件，不可恢复。
+                </span>
+              </button>
             </div>
             <div className="mt-4 flex justify-end">
               <button


### PR DESCRIPTION
## Summary
- 新增：
  - 从磁盘删除 Demo 文件：Demo 库删除弹窗新增红色「从磁盘删除文件」选项，可永久删除 .dem 及同名 .zip
  文件，确认弹窗会列出具体待删文件名
- 修改：
  - 分页默认值调整：默认每页 12 条（10→12），分页选项改为 12/24/48/96，适配 4 列网格布局，减少最后一页铺不满的情况
  - 缩略卡片队员区域对齐：Team A/B 队员名区域改为固定 50px 高度 + 滚动，不同卡片高度一致
  - 滚动条样式优化：新增 scrollbar-hover 类（默认隐藏，悬停显示），滚动条颜色对比度提升
  - Electron 窗口宽度：初始宽度 +100px（1600→1700），minWidth 同步调整

原来：

<img width="1580" height="885" alt="Screenshot 2026-05-24 152659" src="https://github.com/user-attachments/assets/ad6fb8bc-5a25-44d9-a2ca-28a46a224346" />

现在：

<img width="1675" height="993" alt="Screenshot 2026-05-24 152638" src="https://github.com/user-attachments/assets/c876826b-16ea-42f7-8318-77be0347a3c7" />
