### PR TITLE
feat: OBS 自动拉起时检测尝试与自动最小化

### DIFF
--- a/backend/app/env_utils.py
+++ b/backend/app/env_utils.py
@@ -12,6 +12,7 @@ import logging
 import os
 import re
 import shutil
+import sys
 from pathlib import Path
 from typing import Any, Optional
 from urllib.parse import urlparse
@@ -685,6 +686,75 @@ def detect_obs_path() -> Optional[str]:
     if found:
         return str(Path(found).resolve())
     return None
+
+
+def minimize_obs_window() -> None:
+    """最小化 OBS 主窗口。仅 Windows 生效；非 Windows 为 no-op。
+
+    先通过 tasklist 找 obs64.exe/obs32.exe 的 PID，再按 PID + 可见窗口匹配。
+    OBS 进程起来后需要一点时间才创建窗口，因此内部带重试。
+    """
+    if sys.platform != "win32":
+        return
+    try:
+        import ctypes
+        import subprocess as _sp
+        import time as _t
+
+        SW_MINIMIZE = 2
+
+        def _get_obs_pids() -> set[int]:
+            obs_pids: set[int] = set()
+            try:
+                result = _sp.run(
+                    ["tasklist", "/FI", "IMAGENAME eq obs64.exe", "/NH", "/FO", "CSV"],
+                    capture_output=True, text=True, timeout=10,
+                )
+                for line in result.stdout.splitlines():
+                    parts = [p.strip().strip('"') for p in line.split(",")]
+                    if len(parts) >= 2 and parts[0] and parts[1].isdigit():
+                        obs_pids.add(int(parts[1]))
+            except Exception:
+                pass
+            return obs_pids
+
+        def _find_visible_hwnd(obs_pids: set[int]):
+            found = None
+
+            WNDENUMPROC = ctypes.WINFUNCTYPE(
+                ctypes.c_bool, ctypes.c_void_p, ctypes.c_long
+            )
+
+            def enum_callback(hwnd, _lparam):
+                nonlocal found
+                if not ctypes.windll.user32.IsWindowVisible(hwnd):
+                    return True
+                pid_buf = ctypes.c_ulong(0)
+                ctypes.windll.user32.GetWindowThreadProcessId(hwnd, ctypes.byref(pid_buf))
+                if pid_buf.value not in obs_pids:
+                    return True
+                found = hwnd
+                return False
+
+            ctypes.windll.user32.EnumWindows(WNDENUMPROC(enum_callback), 0)
+            return found
+
+        # 重试最多 5 次，每 0.5 秒一次，给 OBS 时间创建窗口
+        for _attempt in range(5):
+            obs_pids = _get_obs_pids()
+            if not obs_pids:
+                logger.warning("OBS process not found for minimization")
+                return
+            hwnd = _find_visible_hwnd(obs_pids)
+            if hwnd:
+                ctypes.windll.user32.ShowWindow(hwnd, SW_MINIMIZE)
+                logger.info("Minimized OBS window (hwnd=%d, pid=%d)", hwnd, list(obs_pids)[0])
+                return
+            _t.sleep(0.5)
+
+        logger.warning("No visible OBS window found after retries (PIDs: %s)", obs_pids)
+    except Exception as e:
+        logger.warning("Failed to minimize OBS window: %s", e)
 
 
 def ensure_cs2_path(cfg: AppConfig) -> AppConfig:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -36,6 +36,7 @@ from .env_utils import (
     detect_cs2_path,
     detect_ffmpeg_path,
     detect_obs_path,
+    minimize_obs_window,
     resolve_config_path,
     llm_api_key_configured,
     llm_base_url_is_local_host,
@@ -294,6 +295,10 @@ UPLOAD_DIR.mkdir(exist_ok=True)
 
 logger = logging.getLogger(__name__)
 
+# 防止并发请求同时拉起多个 OBS（React StrictMode 双重挂载导致请求发两次）
+import threading
+
+_obs_launch_lock = threading.Lock()
 
 def _resolve_web_dist_dir() -> Optional[Path]:
     """
@@ -1111,27 +1116,29 @@ def obs_config_check(payload: OBSConfig | None = Body(default=None)):
     logger.info("[OBS config-check] obs_path=%r", obs_path)
 
     if obs_path and Path(obs_path).is_file():
-        running = _is_obs_process_running(obs_path)
-        logger.info("[OBS config-check] Path OK, OBS already running=%s", running)
-        if not running:
-            logger.info("[OBS config-check] Launching OBS: %s", obs_path)
-            try:
-                subprocess.Popen([obs_path], cwd=str(Path(obs_path).parent))
-                launched_obs = True
+        with _obs_launch_lock:
+            # 双重检查：第一个请求可能已经拉起了 OBS
+            running = _is_obs_process_running(obs_path)
+            logger.info("[OBS config-check] Path OK, OBS already running=%s", running)
+            if not running:
+                logger.info("[OBS config-check] Launching OBS: %s", obs_path)
+                try:
+                    subprocess.Popen([obs_path], cwd=str(Path(obs_path).parent))
+                    launched_obs = True
+                    path_ok = True
+                    # 轮询等待 OBS 进程出现，最多 15 秒
+                    for _attempt in range(30):
+                        if _is_obs_process_running(obs_path):
+                            break
+                        _time.sleep(0.5)
+                    else:
+                        logger.warning("[OBS config-check] OBS did not appear after 15s; continuing anyway")
+                    _time.sleep(1)
+                except Exception as e:
+                    logger.error("[OBS config-check] Failed to launch OBS: %s", e)
+                    return {"path_ok": False, "error": f"无法启动 OBS: {e}"}
+            else:
                 path_ok = True
-                # 轮询等待 OBS 进程出现，最多 15 秒
-                for _attempt in range(30):
-                    if _is_obs_process_running(obs_path):
-                        break
-                    _time.sleep(0.5)
-                else:
-                    logger.warning("[OBS config-check] OBS did not appear after 15s; continuing anyway")
-                _time.sleep(1)
-            except Exception as e:
-                logger.error("[OBS config-check] Failed to launch OBS: %s", e)
-                return {"path_ok": False, "error": f"无法启动 OBS: {e}"}
-        else:
-            path_ok = True
     elif obs_path:
         logger.warning("[OBS config-check] Path configured but file not found: %s", obs_path)
         return {"path_ok": False, "error": "OBS 路径不存在"}
@@ -1145,12 +1152,10 @@ def obs_config_check(payload: OBSConfig | None = Body(default=None)):
         director = OBSDirector(obs_use, cfg.cs2_path)
 
         connected = False
-        obs_version = None
         for _attempt in range(15):
             result = director.test_obs_connection()
             if result.get("ok"):
                 connected = True
-                obs_version = result.get("obs_version")
                 break
             _time.sleep(1)
         else:
@@ -1160,14 +1165,17 @@ def obs_config_check(payload: OBSConfig | None = Body(default=None)):
             _normalize_obs_path_auto_detect(cfg)
             cfg.obs.obs_config_verified = True
             save_config(cfg)
-    except Exception:
+    except Exception as e:
+        logger.warning("[OBS config-check] OBS connection test exception: %s", e)
         connected = False
-        obs_version = None
+
+    # 连接成功后最小化 OBS 窗口（放在 try 外确保执行）
+    if connected:
+        minimize_obs_window()
 
     return {
         "path_ok": path_ok,
         "connected": connected,
-        "obs_version": obs_version,
         "launched_obs": launched_obs,
     }
 

--- a/backend/app/obs_director.py
+++ b/backend/app/obs_director.py
@@ -1989,11 +1989,7 @@ class OBSDirector:
             ws.connect()
             ver = ws.call(obs_requests.GetVersion())
             ws.disconnect()
-            return {
-                "ok": True,
-                "obs_version": ver.getObsVersion(),
-                "ws_version": ver.getObsWebSocketVersion(),
-            }
+            return {"ok": True}
         except Exception as e:
             logger.warning("OBS WebSocket test failed: %s", e, exc_info=True)
             return {"ok": False, "error": _friendly_obs_websocket_test_error(e)}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1614,35 +1614,22 @@ export default function App() {
       );
       return;
     }
-    // 1) 检查 OBS 进程是否在运行
+    // 调用后端配置检查：自动拉起 OBS + 15s 内重试 WebSocket 连接
+    setProgressText("正在检测 OBS 连接…");
     try {
-      const { data: runData } = await API.post("/obs/is-running");
-      if (!runData.running) {
-        setProgressText("检测到 OBS 未运行，正在自动启动…");
-        await API.post("/obs/launch");
-        await new Promise((r) => setTimeout(r, 3000));
-        setProgressText("OBS 已启动，正在检测连接…");
-      }
-    } catch (e) {
-      setProgressText(`OBS 启动失败: ${e.response?.data?.detail || e.message}`);
-      return;
-    }
-    // 2) 测试 WebSocket 连接
-    try {
-      const { data } = await API.get("/status/setup");
-      if (!data?.obs_connected) {
-        setProgressText(
-          "无法连接 OBS。请在开始录制前确认 OBS 已运行且 WebSocket 配置正确。",
-        );
+      const { data } = await API.post("/obs/config-check", obsConfig);
+      if (!data?.connected) {
+        setProgressText("无法连接 OBS。请在开始录制前确认 OBS 已运行且 WebSocket 配置正确。");
         return;
       }
     } catch (e) {
-      setProgressText("OBS 连通性检测失败，请稍后重试。");
+      setProgressText(`OBS 连接检测失败: ${e.response?.data?.detail || e.message}`);
       return;
     }
     setQueueDrawerOpen(false);
     setWarmupIntent("batch");
     setRecordWarmupOpen(true);
+    setProgressText("");
   }, [queue.length, configBackupStatus?.restore_required, setProgressText]);
 
   const handleWarmupConfirm = useCallback(
@@ -1706,6 +1693,7 @@ export default function App() {
           if (allSucceeded) clearQueue();
           setRecordingResults(annotated);
           setRecordingResultModalOpen(true);
+          setProgressText("", { autoDismissMs: 100 });
         } catch (e) {
           const detail = formatRecordingApiError(e);
           if (e.response?.status === 409 || e.response?.status === 422) {
@@ -2409,7 +2397,7 @@ export default function App() {
             <div className="pointer-events-auto w-full max-w-lg shadow-2xl shadow-black/50">
               <ProgressBar
                 text={progressText || (batchRecording ? "正在批量录制…" : "")}
-                active={anyDemoParsing}
+                active={anyDemoParsing || (progressText && !batchRecording && !progressToastMeta?.autoDismissMs)}
                 batchRecording={batchRecording}
                 onAbortBatch={handleAbortBatchRecording}
                 dismissible={Boolean(progressText?.trim())}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -15,10 +15,8 @@ function ThemeApplier() {
 }
 
 ReactDOM.createRoot(document.getElementById("root")).render(
-  <React.StrictMode>
-    <BrowserRouter>
-      <ThemeApplier />
-      <App />
-    </BrowserRouter>
-  </React.StrictMode>,
+  <BrowserRouter>
+    <ThemeApplier />
+    <App />
+  </BrowserRouter>,
 );


### PR DESCRIPTION
## Summary
- 优化：
  - OBS 拉起后如果链接成功，则自动最小化窗口
- 修复：
  - 点击「开始录制」时，可能因为启动 OBS时间过长，导致没能检测到
- 其他：
  - 移除 React.StrictMode，解决开发模式下所有请求 ×2、反复拉起多个 OBS 的问题
  - 后端加线程锁 + 双重检查，防止并发请求导致的多实例 OBS 拉起
  - 修复录制完成后底部进度条转圈不止的问题
  - 修复 `getObsVersion()` 在某些 OBS 版本上抛 KeyError 的崩溃

  ## Test plan
  - [X] 进入 OBS 配置中心，未启动 OBS 时自动拉起、连接成功后最小化窗口
  - [X] 点击「开始录制」，观察 OBS 自动拉起后自动最小化，不再出现多个 OBS 实例
  - [X] 录制完成后进度条转圈自动停止