### PR TITLE
feat: batch RivalHub export + fix team names

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2027,6 +2027,7 @@ async def export_rivalhub_batch(body: BatchExportRivalHubBody):
     exported = 0
     skipped: list[int] = []
 
+    name_counter: dict[str, int] = {}
     with zipfile.ZipFile(batch_buf, "w", zipfile.ZIP_DEFLATED) as zf:
         for demo_id in body.demo_ids:
             item = await demo_db.get_demo_by_id(demo_id)
@@ -2047,7 +2048,10 @@ async def export_rivalhub_batch(body: BatchExportRivalHubBody):
                 continue
             map_name = str(item.get("map_name") or "unknown").replace(" ", "_")
             date_str = (item.get("match_date") or "")[:10] or "unknown"
-            entry_name = f"rivalhub-{map_name}-{date_str}.zip"
+            base = f"rivalhub-{map_name}-{date_str}"
+            n = name_counter.get(base, 0) + 1
+            name_counter[base] = n
+            entry_name = f"{base}.zip" if n == 1 else f"{base}-{n}.zip"
             zf.writestr(entry_name, zip_bytes)
             exported += 1
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -13,6 +13,7 @@ import subprocess
 import sys
 import tempfile
 import uuid
+import zipfile
 from datetime import datetime
 from contextlib import asynccontextmanager
 from pathlib import Path
@@ -2009,6 +2010,56 @@ async def export_demo_rivalhub(demo_id: int):
         io.BytesIO(zip_bytes),
         media_type="application/zip",
         headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )
+
+
+class BatchExportRivalHubBody(BaseModel):
+    demo_ids: list[int]
+
+
+@app.post("/api/demos/export-rivalhub-batch")
+async def export_rivalhub_batch(body: BatchExportRivalHubBody):
+    """批量导出多个 demo 为 RivalHub 格式，合并为一个 zip 返回。"""
+    from .rivalhub_exporter import export_demo as _export_rivalhub_demo
+    from .demo_parse_isolation import IsolatedParseError
+
+    batch_buf = io.BytesIO()
+    exported = 0
+    skipped: list[int] = []
+
+    with zipfile.ZipFile(batch_buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        for demo_id in body.demo_ids:
+            item = await demo_db.get_demo_by_id(demo_id)
+            if item is None:
+                skipped.append(demo_id)
+                continue
+            dem_path = item.get("path") or ""
+            if not dem_path or not Path(dem_path).exists():
+                skipped.append(demo_id)
+                continue
+            try:
+                loop = asyncio.get_running_loop()
+                zip_bytes = await loop.run_in_executor(
+                    None, _export_rivalhub_demo, dem_path
+                )
+            except IsolatedParseError:
+                skipped.append(demo_id)
+                continue
+            map_name = str(item.get("map_name") or "unknown").replace(" ", "_")
+            date_str = (item.get("match_date") or "")[:10] or "unknown"
+            entry_name = f"rivalhub-{map_name}-{date_str}.zip"
+            zf.writestr(entry_name, zip_bytes)
+            exported += 1
+
+    batch_buf.seek(0)
+    detail = {"exported": exported, "skipped": skipped}
+    return StreamingResponse(
+        batch_buf,
+        media_type="application/zip",
+        headers={
+            "Content-Disposition": 'attachment; filename="rivalhub-exports.zip"',
+            "X-Export-Detail": json.dumps(detail),
+        },
     )
 
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2047,7 +2047,7 @@ async def export_rivalhub_batch(body: BatchExportRivalHubBody):
                 skipped.append(demo_id)
                 continue
             map_name = str(item.get("map_name") or "unknown").replace(" ", "_")
-            date_str = (item.get("match_date") or "")[:10] or "unknown"
+            date_str = (item.get("match_date") or item.get("added_at") or "")[:10] or "unknown"
             base = f"rivalhub-{map_name}-{date_str}"
             n = name_counter.get(base, 0) + 1
             name_counter[base] = n

--- a/backend/app/rivalhub_exporter.py
+++ b/backend/app/rivalhub_exporter.py
@@ -288,14 +288,16 @@ def _build_match(raw: dict, rounds: list[dict]) -> dict:
     hdr = raw.get("header", {})
     team_a_score = sum(1 for r in rounds if r["winnerTeamKey"] == "teamA")
     team_b_score = sum(1 for r in rounds if r["winnerTeamKey"] == "teamB")
+    team_a_name = raw.get("team_a_name") or str(hdr.get("team_name_t") or "Team A")
+    team_b_name = raw.get("team_b_name") or str(hdr.get("team_name_ct") or "Team B")
     return {
         "mapName": str(hdr.get("map_name") or "unknown"),
         "tickrate": raw.get("tickrate", 64),
         "durationSeconds": float(hdr.get("playback_time") or 0),
         "serverName": str(hdr.get("server_name") or ""),
         "source": "demo",
-        "teamA": {"teamKey": "teamA", "name": str(hdr.get("team_name_t") or "Team A"), "score": team_a_score},
-        "teamB": {"teamKey": "teamB", "name": str(hdr.get("team_name_ct") or "Team B"), "score": team_b_score},
+        "teamA": {"teamKey": "teamA", "name": team_a_name, "score": team_a_score},
+        "teamB": {"teamKey": "teamB", "name": team_b_name, "score": team_b_score},
     }
 
 

--- a/backend/app/rivalhub_parse_worker.py
+++ b/backend/app/rivalhub_parse_worker.py
@@ -170,6 +170,26 @@ def parse_for_rivalhub(dem_path: str) -> dict[str, Any]:
     else:
         match_start_tick = 1
 
+    # ── team names from CCSTeam entity ──────────────────────────
+    team_a_name: str | None = None
+    team_b_name: str | None = None
+    try:
+        team_rows = _rows(p.parse_ticks(
+            ["CCSTeam.m_szClanTeamname", "CCSTeam.m_iTeamNum"],
+            ticks=[match_start_tick],
+        ))
+        for row in team_rows:
+            tn = row.get("CCSTeam.m_iTeamNum")
+            name = str(row.get("CCSTeam.m_szClanTeamname") or "").strip()
+            if not name or name.lower() in ("ct", "terrorist", "t"):
+                continue
+            if tn == 2:
+                team_a_name = name
+            elif tn == 3:
+                team_b_name = name
+    except BaseException:
+        pass
+
     try:
         player_info = _rows(p.parse_ticks(
             ["name", "steamid", "team_num", "team_name"],
@@ -210,6 +230,8 @@ def parse_for_rivalhub(dem_path: str) -> dict[str, Any]:
         "header": header,
         "tickrate": tickrate,
         "match_start_tick": match_start_tick,
+        "team_a_name": team_a_name,
+        "team_b_name": team_b_name,
         "player_info": player_info,
         "round_starts": round_starts,
         "round_freeze_ends": round_freeze_ends,

--- a/frontend/src/pages/DemoLibraryPage.jsx
+++ b/frontend/src/pages/DemoLibraryPage.jsx
@@ -1,6 +1,6 @@
 import { useCallback, useMemo, useState } from "react";
 import API from "../api/api";
-import { LayoutGrid, List } from "lucide-react";
+import { LayoutGrid, List, Loader2, AlertCircle, CheckCircle2, X } from "lucide-react";
 import PageContainer from "../components/PageContainer";
 import { useAppShell } from "../context/AppShellContext";
 import { useRecordingQueue } from "../stores/recordingQueueStore";
@@ -18,8 +18,7 @@ import {
   filterByPathAndTags,
   sortDemoRows,
 } from "../utils/demoLibraryDisplay";
-import { exportRivalHubBatch } from "../utils/rivalHubExport";
-import RivalHubExportToast from "../components/demoLibrary/RivalHubExportToast";
+import { exportRivalHubBatch, downloadBlob } from "../utils/rivalHubExport";
 
 const INITIAL_ADV_FILTERS = {
   mapName: "",
@@ -51,8 +50,7 @@ export default function DemoLibraryPage() {
   const [demoInfoModalId, setDemoInfoModalId] = useState(null);
   const [ingestModalOpen, setIngestModalOpen] = useState(false);
 
-  // rivalHubToasts: { id: number, label: string, phase: string, blob?: Blob, filename?: string, error?: string }[]
-  const [rivalHubToasts, setRivalHubToasts] = useState([]);
+  const [rivalHubExport, setRivalHubExport] = useState({ phase: "idle", error: "" });
 
   const queuedClientClipUids = useMemo(
     () => new Set(queue.map((q) => q.clientClipUid).filter(Boolean)),
@@ -231,43 +229,27 @@ export default function DemoLibraryPage() {
     [s]
   );
 
-  const handleExportRivalHub = useCallback(() => {
+  const handleExportRivalHub = useCallback(async () => {
     const selectedIds = Array.from(s.selectedLibraryDemoIds);
-    // RivalHub export re-parses the .dem in isolation — no Insight parse/result required.
-    const exportItems = selectedIds
-      .map((id) => s.demoLibraryItems.find((it) => it.id === id))
-      .filter(Boolean);
-    if (!exportItems.length) return;
+    if (!selectedIds.length) return;
 
-    // filter out demos already being exported
-    setRivalHubToasts((prev) => {
-      const inFlight = new Set(prev.filter(t => t.phase === "loading").map(t => t.id));
-      const newItems = exportItems.filter(it => !inFlight.has(it.id));
-      if (!newItems.length) return prev;
-
-      const ids = newItems.map((it) => it.id);
-      void exportRivalHubBatch(ids, (demoId, status) => {
-        setRivalHubToasts((p) =>
-          p.map((t) => (t.id === demoId ? { ...t, ...status } : t))
-        );
+    setRivalHubExport({ phase: "loading", error: "" });
+    try {
+      const { blob, filename, exported, skipped } = await exportRivalHubBatch(selectedIds);
+      downloadBlob(blob, filename);
+      setRivalHubExport({
+        phase: "done",
+        error: skipped.length ? `跳过 ${skipped.length} 个（解析失败），成功 ${exported} 个` : `成功导出 ${exported} 个`,
       });
-
-      return [
-        ...prev,
-        ...newItems.map((it) => ({
-          id: it.id,
-          label:
-            (it.display_name && String(it.display_name).trim()) ||
-            it.filename ||
-            `Demo #${it.id}`,
-          phase: "loading",
-        })),
-      ];
-    });
+      setTimeout(() => setRivalHubExport({ phase: "idle", error: "" }), 10_000);
+    } catch (err) {
+      const msg = err?.response?.data?.detail || err?.message || "导出失败";
+      setRivalHubExport({ phase: "error", error: String(msg) });
+    }
   }, [s]);
 
-  const handleCloseToast = useCallback((id) => {
-    setRivalHubToasts((prev) => prev.filter((t) => t.id !== id));
+  const handleCloseToast = useCallback(() => {
+    setRivalHubExport({ phase: "idle", error: "" });
   }, []);
 
   return (
@@ -527,20 +509,30 @@ export default function DemoLibraryPage() {
         onIngest={handleBatchIngest}
         onUpload={s.handleUpload}
       />
-      {rivalHubToasts.length > 0 && (
-        <div className="fixed bottom-4 right-4 z-50 flex flex-col gap-2">
-          {rivalHubToasts.map((t) => (
-            <RivalHubExportToast
-              key={t.id}
-              id={t.id}
-              label={t.label}
-              phase={t.phase}
-              blob={t.blob}
-              filename={t.filename}
-              error={t.error}
-              onClose={handleCloseToast}
-            />
-          ))}
+      {rivalHubExport.phase !== "idle" && (
+        <div className="fixed bottom-4 right-4 z-50">
+          {rivalHubExport.phase === "loading" ? (
+            <div className="flex items-center gap-2 rounded-lg border border-cs2-border bg-cs2-bg-card/95 px-3 py-2.5 shadow-lg backdrop-blur-sm text-[12px] text-cs2-text-secondary">
+              <Loader2 className="h-3.5 w-3.5 animate-spin text-cs2-accent" />
+              正在批量导出 RivalHub…
+            </div>
+          ) : (
+            <div className={`flex items-start gap-2.5 rounded-lg border px-3 py-2.5 shadow-lg backdrop-blur-sm text-[12px] max-w-[360px] ${
+              rivalHubExport.phase === "error"
+                ? "border-cs2-fail/40 text-cs2-red-on-surface"
+                : "border-cs2-highlight/40 text-cs2-text-primary"
+            }`}>
+              {rivalHubExport.phase === "error" ? (
+                <AlertCircle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-cs2-fail" />
+              ) : (
+                <CheckCircle2 className="mt-0.5 h-3.5 w-3.5 shrink-0 text-cs2-highlight" />
+              )}
+              <span className="flex-1">{rivalHubExport.error}</span>
+              <button type="button" onClick={handleCloseToast} className="shrink-0 text-cs2-text-muted hover:text-cs2-text-primary">
+                <X className="h-3.5 w-3.5" />
+              </button>
+            </div>
+          )}
         </div>
       )}
     </PageContainer>

--- a/frontend/src/utils/rivalHubExport.js
+++ b/frontend/src/utils/rivalHubExport.js
@@ -1,46 +1,36 @@
 import API from "../api/api";
 
 /**
- * Export a batch of demos as RivalHub zips.
- * Calls onUpdate(demoId, status) where status is:
- *   { phase: "pending" | "loading" | "done" | "error", blob?: Blob, filename?: string, error?: string }
+ * Export all selected demos as a single merged RivalHub zip.
+ * Returns the Blob on success, or throws on error.
  *
  * @param {number[]} demoIds
- * @param {(id: number, status: object) => void} onUpdate
- * @param {number} [concurrency=2]
+ * @returns {Promise<{ blob: Blob, filename: string, exported: number, skipped: number[] }>}
  */
-export async function exportRivalHubBatch(demoIds, onUpdate, concurrency = 2) {
-  const queue = [...demoIds];
+export async function exportRivalHubBatch(demoIds) {
+  const response = await API.post(
+    "/demos/export-rivalhub-batch",
+    { demo_ids: demoIds },
+    { responseType: "blob" }
+  );
 
-  async function worker() {
-    while (queue.length > 0) {
-      const id = queue.shift();
-      if (id == null) break;
-      onUpdate(id, { phase: "loading" });
-      try {
-        const response = await API.post(
-          `/demos/${id}/export-rivalhub`,
-          {},
-          { responseType: "blob" }
-        );
-        const blob = new Blob([response.data], { type: "application/zip" });
-        const disposition = response.headers?.["content-disposition"] || "";
-        const match = disposition.match(/filename="?([^";\n]+)"?/i);
-        const filename = match?.[1] || `rivalhub-demo-${id}.zip`;
-        onUpdate(id, { phase: "done", blob, filename });
-      } catch (err) {
-        const msg =
-          err?.response?.data instanceof Blob
-            ? await err.response.data.text().then((t) => {
-                try { return JSON.parse(t).detail; } catch { return t; }
-              })
-            : err?.response?.data?.detail || err?.message || "导出失败";
-        onUpdate(id, { phase: "error", error: String(msg) });
-      }
-    }
+  const detailHeader = response.headers?.["x-export-detail"];
+  let exported = 0;
+  let skipped = [];
+  if (detailHeader) {
+    try {
+      const detail = JSON.parse(detailHeader);
+      exported = detail.exported ?? 0;
+      skipped = detail.skipped ?? [];
+    } catch { /* ignore */ }
   }
 
-  await Promise.all(Array.from({ length: concurrency }, worker));
+  return {
+    blob: new Blob([response.data], { type: "application/zip" }),
+    filename: "rivalhub-exports.zip",
+    exported,
+    skipped,
+  };
 }
 
 /**


### PR DESCRIPTION
## Summary

- **批量导出**：新增 `POST /api/demos/export-rivalhub-batch` 端点，服务端合并多个 RivalHub zip 为一个文件返回，前端单次点击即下载
- **队伍名修复**：从 CCSTeam entity 提取真实战队名，替代硬编码的 "Team A / Team B"
- **前端优化**：去掉逐个 toast + 逐个手动下载，一键完成

## Changes

### Backend
- `rivalhub_parse_worker.py` — 解析 CCSTeam entity 提取队伍名
- `rivalhub_exporter.py` — `_build_match` 使用真实队名
- `main.py` — 新增批量导出端点

### Frontend
- `rivalHubExport.js` — 重写为调用批量端点
- `DemoLibraryPage.jsx` — 简化为单次加载 + 自动下载

## Test plan
1. 选择多个 demo → 点「导出 RivalHub」→ 下载 rivalhub-exports.zip
2. 解压检查内部各 zip 的 match.json，队伍名为真实名称
