### PR TITLE
修复 Demo 路径穿越与任意路径执行

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ frontend/dist/
 # IDE
 .vscode/
 .idea/
+.qoder/
 
 # OS
 .DS_Store

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -409,6 +409,24 @@ def resolve_uploaded_demo_path(p: str) -> Path:
     raise HTTPException(404, f"未找到 Demo 文件: {raw}")
 
 
+def resolve_demo_upload_path(filename: str) -> Path:
+    """Resolve an uploaded demo without allowing paths outside ``UPLOAD_DIR``."""
+    raw = (filename or "").strip()
+    if not raw:
+        raise HTTPException(400, "Demo 文件名为空")
+
+    upload_root = UPLOAD_DIR.resolve()
+    candidate = (upload_root / raw).resolve()
+    try:
+        candidate.relative_to(upload_root)
+    except ValueError as exc:
+        raise HTTPException(400, "Demo 文件路径超出上传目录") from exc
+
+    if not candidate.is_file():
+        raise HTTPException(404, f"Demo file not found: {filename}")
+    return candidate
+
+
 def _analyze_demo_sync(
     dem_path: str,
     target_player: str,
@@ -1412,9 +1430,7 @@ async def upload_demos(files: Annotated[list[UploadFile], File()]):
 async def parse_demo(req: ParseRequest, filename: str):
     from .demo_parse_isolation import IsolatedParseError
 
-    dem_path = UPLOAD_DIR / filename
-    if not dem_path.exists():
-        raise HTTPException(404, f"Demo file not found: {filename}")
+    dem_path = resolve_demo_upload_path(filename)
 
     try:
         result = await asyncio.to_thread(
@@ -1454,9 +1470,7 @@ async def parse_demo_multi(req: ParseMultiRequest, filename: str):
     """多玩家解析：对同一个 Demo 依次分析每个目标玩家，返回 { players: { name: result } }。"""
     from .demo_parse_isolation import IsolatedParseError
 
-    dem_path = UPLOAD_DIR / filename
-    if not dem_path.exists():
-        raise HTTPException(status_code=404, detail=f"Demo file not found: {filename}")
+    dem_path = resolve_demo_upload_path(filename)
 
     cfg = load_config()
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1367,13 +1367,15 @@ async def upload_demo(file: UploadFile = File(...)):
     if not file.filename or not file.filename.endswith(".dem"):
         raise HTTPException(400, "Only .dem files are accepted")
 
-    dest = UPLOAD_DIR / file.filename
+    # H2 fix: 取纯文件名，防止路径穿越（如 ../../etc/passwd.dem）
+    safe_name = Path(file.filename).name
+    dest = UPLOAD_DIR / safe_name
     with dest.open("wb") as f:
         shutil.copyfileobj(file.file, f)
 
     players, match_meta = await _safe_upload_demo_meta(dest)
     return {
-        "filename": file.filename,
+        "filename": safe_name,
         "path": str(dest),
         "players": players,
         "match_meta": match_meta,
@@ -1389,13 +1391,15 @@ async def upload_demos(files: Annotated[list[UploadFile], File()]):
     for file in files:
         if not file.filename or not str(file.filename).lower().endswith(".dem"):
             raise HTTPException(400, f"仅接受 .dem 文件: {file.filename!r}")
-        dest = UPLOAD_DIR / file.filename
+        # H2 fix: 取纯文件名，防止路径穿越
+        safe_name = Path(file.filename).name
+        dest = UPLOAD_DIR / safe_name
         with dest.open("wb") as f:
             shutil.copyfileobj(file.file, f)
         players, match_meta = await _safe_upload_demo_meta(dest)
         out.append(
             {
-                "filename": file.filename,
+                "filename": safe_name,
                 "path": str(dest),
                 "players": players,
                 "match_meta": match_meta,
@@ -2732,15 +2736,30 @@ class RevealFileInExplorerBody(BaseModel):
 
 @app.post("/api/open-folder")
 def open_folder(body: OpenFolderBody):
+    """在文件管理器中打开指定目录。
+
+    H3 fix: 仅允许打开**已存在的目录**，拒绝文件和含路径穿越的输入，
+    防止通过 os.startfile 启动任意可执行程序。
+    """
     import os, subprocess as sp, sys
-    p = body.path.strip()
+    raw = body.path.strip()
+    # 拒绝路径穿越
+    if ".." in raw.split("/") or ".." in raw.split("\\"):
+        raise HTTPException(400, "路径不允许包含 '..'")
+    try:
+        p = Path(raw).expanduser().resolve()
+    except OSError as exc:
+        raise HTTPException(400, f"无效路径: {exc}") from exc
+    if not p.is_dir():
+        raise HTTPException(400, "仅支持打开目录，不支持打开文件或可执行程序")
+    path_str = str(p)
     try:
         if sys.platform == "win32":
-            os.startfile(p)  # noqa: S606
+            os.startfile(path_str)  # noqa: S606
         elif sys.platform == "darwin":
-            sp.run(["open", p], check=False, timeout=10)
+            sp.run(["open", path_str], check=False, timeout=10)
         else:
-            sp.run(["xdg-open", p], check=False, timeout=10)
+            sp.run(["xdg-open", path_str], check=False, timeout=10)
     except Exception as e:
         raise HTTPException(400, str(e)) from e
     return {"ok": True}
@@ -2748,26 +2767,37 @@ def open_folder(body: OpenFolderBody):
 
 @app.post("/api/reveal-file-in-explorer")
 def reveal_file_in_explorer(body: RevealFileInExplorerBody):
-    """在文件管理器中显示该 Demo：Windows 资源管理器 /select；macOS Finder -R；Linux 打开所在目录。"""
+    """在文件管理器中显示该 Demo：Windows 资源管理器 /select；macOS Finder -R；Linux 打开所在目录。
+
+    H3 fix: 仅允许显示已存在的文件，拒绝含路径穿越的输入和可执行程序。
+    """
     import subprocess as sp
     import sys
 
     raw = (body.path or "").strip().strip('"')
     if not raw:
         raise HTTPException(400, "path 为空")
+    # 拒绝路径穿越
+    if ".." in raw.split("/") or ".." in raw.split("\\"):
+        raise HTTPException(400, "路径不允许包含 '..'")
     try:
         p = Path(raw).expanduser().resolve(strict=False)
     except OSError as exc:
         raise HTTPException(400, f"无效路径: {exc}") from exc
     if not p.exists():
         raise HTTPException(404, f"路径不存在: {p}")
+    if not p.is_file():
+        raise HTTPException(400, "仅支持显示文件，不支持目录或可执行程序")
+    # 拒绝可执行程序
+    if p.suffix.lower() in (".exe", ".bat", ".cmd", ".ps1", ".msi", ".com"):
+        raise HTTPException(400, "不允许打开可执行程序文件")
     try:
         if sys.platform == "win32":
             if p.is_dir():
                 os.startfile(str(p))  # noqa: S606
             else:
                 # `/select, <path>` 分成两个参数更稳；把路径拼进同一个参数时，
-                # Explorer 在含空格/特殊字符场景下可能退回默认“文档”目录。
+                # Explorer 在含空格/特殊字符场景下可能退回默认"文档"目录。
                 sp.Popen(["explorer.exe", "/select,", str(p)])
         elif sys.platform == "darwin":
             sp.run(["open", "-R", str(p)], check=False, timeout=20)

--- a/backend/tests/test_demo_upload_path_safety.py
+++ b/backend/tests/test_demo_upload_path_safety.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+
+import pytest
+from fastapi import HTTPException
+
+from app import main
+
+
+def test_resolve_demo_upload_path_accepts_file_inside_upload_dir(tmp_path, monkeypatch):
+    demo = tmp_path / "match.dem"
+    demo.write_bytes(b"demo")
+    monkeypatch.setattr(main, "UPLOAD_DIR", tmp_path)
+
+    assert main.resolve_demo_upload_path("match.dem") == demo.resolve()
+
+
+@pytest.mark.parametrize("filename", ["../outside.dem", "nested/../../outside.dem"])
+def test_resolve_demo_upload_path_rejects_parent_traversal(tmp_path, monkeypatch, filename):
+    outside = tmp_path.parent / "outside.dem"
+    outside.write_bytes(b"demo")
+    monkeypatch.setattr(main, "UPLOAD_DIR", tmp_path)
+
+    with pytest.raises(HTTPException) as exc_info:
+        main.resolve_demo_upload_path(filename)
+
+    assert exc_info.value.status_code == 400
+
+
+def test_resolve_demo_upload_path_rejects_absolute_path(tmp_path, monkeypatch):
+    outside = tmp_path.parent / "outside.dem"
+    outside.write_bytes(b"demo")
+    monkeypatch.setattr(main, "UPLOAD_DIR", tmp_path)
+
+    with pytest.raises(HTTPException) as exc_info:
+        main.resolve_demo_upload_path(str(Path(outside).resolve()))
+
+    assert exc_info.value.status_code == 400


### PR DESCRIPTION
## 修复内容
- 将 Demo 上传和解析路径限制在 `UPLOAD_DIR` 内，拒绝绝对路径、`..` 逃逸及目录外目标。
- `open-folder` 仅允许打开现有目录；`reveal-file-in-explorer` 拒绝无效路径和可执行文件。

## 验证
- 4 个路径安全回归测试通过。
