### PR TITLE
加强 Electron API 认证与 IPC 安全

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ frontend/dist/
 # IDE
 .vscode/
 .idea/
+.qoder/
 
 # OS
 .DS_Store

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -279,15 +279,6 @@ app = FastAPI(title="CS2 Insight Agent", version="2.0.2", lifespan=lifespan)
 
 app.include_router(recording_router)
 
-# C2 fix: 收窄 CORS 来源，仅允许 Electron app:// 协议和本地开发服务器
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=["app://local", "http://localhost:5173"],
-    allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
-)
-
 # H1 fix: 从环境变量读取认证 Token，要求所有请求携带该 Token
 _AUTH_TOKEN: str = os.environ.get("CS2_INSIGHT_AUTH_TOKEN", "")
 
@@ -315,6 +306,18 @@ async def log_unhandled_http_errors(request: Request, call_next):
     except Exception:
         logger.exception("Unhandled request error: %s %s", request.method, request.url.path)
         raise
+
+
+# Keep CORS outermost so preflight requests and auth failures receive the
+# headers required by the Electron renderer.
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["app://local", "http://localhost:5173"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
 
 UPLOAD_DIR = Path(tempfile.gettempdir()) / "cs2_insight_demos"
 UPLOAD_DIR.mkdir(exist_ok=True)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -23,7 +23,7 @@ import faulthandler
 
 from fastapi import Body, FastAPI, File, HTTPException, Query, Request, UploadFile
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import FileResponse, StreamingResponse
+from fastapi.responses import FileResponse, JSONResponse, StreamingResponse
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel, Field
 
@@ -279,13 +279,33 @@ app = FastAPI(title="CS2 Insight Agent", version="2.0.2", lifespan=lifespan)
 
 app.include_router(recording_router)
 
+# C2 fix: 收窄 CORS 来源，仅允许 Electron app:// 协议和本地开发服务器
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=["app://local", "http://localhost:5173"],
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+# H1 fix: 从环境变量读取认证 Token，要求所有请求携带该 Token
+_AUTH_TOKEN: str = os.environ.get("CS2_INSIGHT_AUTH_TOKEN", "")
+
+
+@app.middleware("http")
+async def auth_token_middleware(request: Request, call_next):
+    """Token 认证中间件：SSE 推送端点豁免（不支持自定义头），其余均须携带有效 Token。"""
+    # SSE 端点豁免：EventSource API 不支持自定义请求头
+    if request.url.path == "/api/demos/stream":
+        return await call_next(request)
+    if _AUTH_TOKEN:
+        token = request.headers.get("X-CS2-Insight-Token", "")
+        if token != _AUTH_TOKEN:
+            return JSONResponse(
+                status_code=401,
+                content={"detail": "Unauthorized: invalid or missing X-CS2-Insight-Token"},
+            )
+    return await call_next(request)
 
 
 @app.middleware("http")

--- a/backend/app/run_server.py
+++ b/backend/app/run_server.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+import secrets
 import sys
 from pathlib import Path
 
@@ -64,6 +65,13 @@ def main() -> None:
         port = int(os.environ.get("CS2_INSIGHT_PORT", "19871"))
     except ValueError:
         port = 19871
+
+    # H1 fix: 生成随机认证 Token，通过环境变量传递给后端进程
+    # 打印到 stdout 供 Electron 主进程捕获并注入到前端请求中
+    token = secrets.token_urlsafe(32)
+    os.environ["CS2_INSIGHT_AUTH_TOKEN"] = token
+    print(f"CS2_INSIGHT_AUTH_TOKEN={token}", flush=True)
+
     uvicorn.run(
         "app.main:app",
         host=host,

--- a/backend/tests/test_api_auth.py
+++ b/backend/tests/test_api_auth.py
@@ -1,0 +1,46 @@
+from fastapi.testclient import TestClient
+
+from app import main
+
+
+ORIGIN = "app://local"
+
+
+def test_cors_preflight_bypasses_token_auth(monkeypatch):
+    monkeypatch.setattr(main, "_AUTH_TOKEN", "secret")
+    client = TestClient(main.app)
+
+    response = client.options(
+        "/api/health",
+        headers={
+            "Origin": ORIGIN,
+            "Access-Control-Request-Method": "GET",
+            "Access-Control-Request-Headers": "X-CS2-Insight-Token",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.headers["access-control-allow-origin"] == ORIGIN
+
+
+def test_auth_rejection_includes_cors_headers(monkeypatch):
+    monkeypatch.setattr(main, "_AUTH_TOKEN", "secret")
+    client = TestClient(main.app)
+
+    response = client.get("/api/health", headers={"Origin": ORIGIN})
+
+    assert response.status_code == 401
+    assert response.headers["access-control-allow-origin"] == ORIGIN
+
+
+def test_valid_token_reaches_api(monkeypatch):
+    monkeypatch.setattr(main, "_AUTH_TOKEN", "secret")
+    client = TestClient(main.app)
+
+    response = client.get(
+        "/api/health",
+        headers={"Origin": ORIGIN, "X-CS2-Insight-Token": "secret"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "ok"

--- a/frontend/backend-auth.cjs
+++ b/frontend/backend-auth.cjs
@@ -1,0 +1,25 @@
+const readline = require('node:readline');
+
+const AUTH_TOKEN_LINE = /^CS2_INSIGHT_AUTH_TOKEN=([A-Za-z0-9_-]+)$/;
+
+
+function attachBackendOutput(stdout, { onToken, onLog }) {
+  const reader = readline.createInterface({
+    input: stdout,
+    crlfDelay: Infinity,
+  });
+
+  reader.on('line', (line) => {
+    const tokenMatch = line.match(AUTH_TOKEN_LINE);
+    if (tokenMatch) {
+      onToken(tokenMatch[1]);
+      return;
+    }
+    onLog(line);
+  });
+
+  return reader;
+}
+
+
+module.exports = { attachBackendOutput };

--- a/frontend/electron-main.cjs
+++ b/frontend/electron-main.cjs
@@ -6,6 +6,7 @@ const path = require('path');
 const { spawn } = require('child_process');
 const fs = require('fs');
 const { pathToFileURL } = require('url');
+const { attachBackendOutput } = require('./backend-auth.cjs');
 
 // 注册自定义协议以支持 Vite 的 ES 模块加载
 protocol.registerSchemesAsPrivileged([
@@ -249,15 +250,12 @@ function startBackend() {
       env: spawnEnv,
     });
 
-    backendProcess.stdout.on('data', (data) => {
-      const text = data.toString().trimEnd();
-      // H1 fix: 捕获后端启动时输出的认证 Token
-      const tokenMatch = text.match(/^CS2_INSIGHT_AUTH_TOKEN=(.+)$/);
-      if (tokenMatch) {
-        backendAuthToken = tokenMatch[1];
+    attachBackendOutput(backendProcess.stdout, {
+      onToken: (token) => {
+        backendAuthToken = token;
         log.info('[Backend] Auth token captured');
-      }
-      log.info(`[Backend] ${text}`);
+      },
+      onLog: (line) => log.info(`[Backend] ${line}`),
     });
 
     backendProcess.stderr.on('data', (data) => {

--- a/frontend/electron-main.cjs
+++ b/frontend/electron-main.cjs
@@ -38,6 +38,7 @@ log.info('App starting...');
 
 let mainWindow;
 let backendProcess;
+let backendAuthToken = null; // H1 fix: 从后端 stdout 捕获的认证 Token
 
 function resolveWindowIconPath() {
   const icoPath = path.join(__dirname, 'build', 'icon.ico');
@@ -67,9 +68,8 @@ function createWindow() {
       preload: path.join(__dirname, 'preload.cjs'),
       nodeIntegration: false,
       contextIsolation: true,
-      // 允许跨域请求后端 API，并加载本地模块 (解决 blocked:origin)
-      webSecurity: false, 
-      allowRunningInsecureContent: true
+      // C1 fix: 恢复 webSecurity，配合后端 CORS 白名单实现跨域请求
+      webSecurity: true,
     }
   });
 
@@ -250,7 +250,14 @@ function startBackend() {
     });
 
     backendProcess.stdout.on('data', (data) => {
-      log.info(`[Backend] ${data.toString().trimEnd()}`);
+      const text = data.toString().trimEnd();
+      // H1 fix: 捕获后端启动时输出的认证 Token
+      const tokenMatch = text.match(/^CS2_INSIGHT_AUTH_TOKEN=(.+)$/);
+      if (tokenMatch) {
+        backendAuthToken = tokenMatch[1];
+        log.info('[Backend] Auth token captured');
+      }
+      log.info(`[Backend] ${text}`);
     });
 
     backendProcess.stderr.on('data', (data) => {
@@ -280,26 +287,27 @@ function startBackend() {
 
 app.whenReady().then(() => {
   // 使用更稳健的 registerFileProtocol
+  // H7 fix: 添加路径遍历检查，确保解析后的路径在 dist 目录内
   protocol.registerFileProtocol('app', (request, callback) => {
-    // 移除 app://local/ 前缀
     const urlPath = request.url.replace(/^app:\/\/local\//, '');
-    // 去除参数
     const cleanPath = urlPath.split('?')[0].split('#')[0];
-    
-    // 关键修复：如果是请求 api，说明前端代码写错了（生产环境必须用 http 绝对路径）
-    // 我们返回错误，而不是 index.html，避免掩盖真实的连接问题
+
     if (cleanPath.startsWith('api/') || cleanPath === 'api') {
+      return callback({ error: -6 });
+    }
+
+    const distRoot = path.resolve(app.getAppPath(), 'dist');
+    const resolved = path.resolve(distRoot, cleanPath || 'index.html');
+    // 路径遍历检查：确保解析后的路径在 dist 目录内
+    if (!resolved.startsWith(distRoot + path.sep) && resolved !== distRoot) {
+      log.warn('[Protocol] Path traversal blocked:', cleanPath);
       return callback({ error: -6 }); // net::ERR_FILE_NOT_FOUND
     }
 
-    // 现在的路径相对于 app.asar，由于我们把 dist 整个打进去了
-    let filePath = path.join(app.getAppPath(), 'dist', cleanPath || 'index.html');
-    
-    // 如果是目录或不存在，回退到 index.html
+    let filePath = resolved;
     if (!fs.existsSync(filePath) || fs.statSync(filePath).isDirectory()) {
-      filePath = path.join(app.getAppPath(), 'dist', 'index.html');
+      filePath = path.join(distRoot, 'index.html');
     }
-    
     callback({ path: filePath });
   });
 
@@ -609,12 +617,24 @@ ipcMain.handle('show-open-dialog', async (event, options) => {
 });
 
 // 打开外部链接（使用系统默认浏览器）
+// H6 fix: 添加 URL 协议白名单，仅允许 http/https/mailto
 ipcMain.handle('open-external', async (event, url) => {
   try {
+    const parsed = new URL(url);
+    const allowedProtocols = ['https:', 'http:', 'mailto:'];
+    if (!allowedProtocols.includes(parsed.protocol)) {
+      log.warn('[Security] Blocked open-external with disallowed protocol:', parsed.protocol);
+      return false;
+    }
     await shell.openExternal(url);
     return true;
   } catch (e) {
     log.error('openExternal error:', e);
     return false;
   }
+});
+
+// H1 fix: 向后端请求提供认证 Token
+ipcMain.handle('get-auth-token', () => {
+  return backendAuthToken;
 });

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -31,6 +31,7 @@
     "files": [
       "dist/**/*",
       "electron-main.cjs",
+      "backend-auth.cjs",
       "preload.cjs",
       "public/cs2-insight-logo.png",
       "build/icon.ico"

--- a/frontend/preload.cjs
+++ b/frontend/preload.cjs
@@ -18,5 +18,7 @@ contextBridge.exposeInMainWorld('electron', {
   },
   showOpenDialog: (options) => ipcRenderer.invoke('show-open-dialog', options),
   // 打开外部链接（使用系统默认浏览器）
-  openExternal: (url) => ipcRenderer.invoke('open-external', url)
+  openExternal: (url) => ipcRenderer.invoke('open-external', url),
+  // H1 fix: 获取后端认证 Token
+  getAuthToken: () => ipcRenderer.invoke('get-auth-token')
 });

--- a/frontend/scripts/backend-auth.test.cjs
+++ b/frontend/scripts/backend-auth.test.cjs
@@ -1,0 +1,24 @@
+const assert = require('node:assert/strict');
+const { PassThrough } = require('node:stream');
+const test = require('node:test');
+
+const { attachBackendOutput } = require('../backend-auth.cjs');
+
+
+test('captures a chunked auth token without logging it', async () => {
+  const stdout = new PassThrough();
+  const tokens = [];
+  const lines = [];
+  const reader = attachBackendOutput(stdout, {
+    onToken: (token) => tokens.push(token),
+    onLog: (line) => lines.push(line),
+  });
+
+  stdout.write('CS2_INSIGHT_AUTH_');
+  stdout.write('TOKEN=abc_123-xyz\nBackend ready');
+  stdout.end('\n');
+  await new Promise((resolve) => reader.once('close', resolve));
+
+  assert.deepEqual(tokens, ['abc_123-xyz']);
+  assert.deepEqual(lines, ['Backend ready']);
+});

--- a/frontend/src/api/api.js
+++ b/frontend/src/api/api.js
@@ -22,14 +22,25 @@ export function getDemosStreamUrl() {
 
 console.log(`[API Init] Protocol: ${window.location.protocol}, IsElectron: ${IS_ELECTRON_APP}, BaseURL: ${API_BASE_URL}`);
 
+// H1 fix: 缓存认证 Token，Electron 环境下从主进程获取
+let _authToken = null;
+
 const API = axios.create({
   baseURL: `${API_BASE_URL}/api`,
 });
 
-API.interceptors.request.use((config) => {
+API.interceptors.request.use(async (config) => {
   const locale = useLocaleStore.getState().locale || "zh";
   config.headers = config.headers ?? {};
   config.headers["X-CS2-Insight-Locale"] = locale;
+
+  // H1 fix: 注入认证 Token
+  if (!_authToken && IS_ELECTRON_APP && window.electron?.getAuthToken) {
+    _authToken = await window.electron.getAuthToken();
+  }
+  if (_authToken) {
+    config.headers["X-CS2-Insight-Token"] = _authToken;
+  }
   return config;
 });
 


### PR DESCRIPTION
## 修复内容
- 启用 `webSecurity`，收紧 CORS 来源，并保证预检和认证失败响应包含正确的 CORS headers。
- 为本地 API 增加随机 Token 认证；Token 按行读取且不写入日志，SSE 端点保持豁免。
- 限制外部链接协议，并阻止 `app://` 路径逃逸。

## 验证
- CORS 与认证测试 3 项、Token 输出解析测试 1 项通过。
