### PR TITLE
统一校验 LLM 服务地址安全性

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ frontend/dist/
 # IDE
 .vscode/
 .idea/
+.qoder/
 
 # OS
 .DS_Store

--- a/backend/app/ai_reviewer.py
+++ b/backend/app/ai_reviewer.py
@@ -18,8 +18,7 @@ from .llm_compat import (
     ai_review_fallback_message,
     completion_extra_body,
     message_text,
-    normalize_llm_base_url,
-    validate_llm_base_url,
+    prepare_llm_base_url,
 )
 
 logger = logging.getLogger(__name__)
@@ -200,9 +199,7 @@ class AIReviewer:
         key = (api_key or "").strip()
         if not key or key.startswith("****"):
             raise ValueError("AIReviewer: invalid or masked api_key")
-        bu = normalize_llm_base_url((base_url or "").strip() or None)
-        # H4 fix: 对非 HTTPS 的未知远程域名记录警告（不拦截）
-        validate_llm_base_url(bu)
+        bu = prepare_llm_base_url((base_url or "").strip() or None)
         self._client = AsyncOpenAI(api_key=key, base_url=bu, timeout=timeout_seconds)
         self._model = (model_name or "").strip() or "gpt-4o-mini"
         self._base_url = bu

--- a/backend/app/ai_reviewer.py
+++ b/backend/app/ai_reviewer.py
@@ -19,6 +19,7 @@ from .llm_compat import (
     completion_extra_body,
     message_text,
     normalize_llm_base_url,
+    validate_llm_base_url,
 )
 
 logger = logging.getLogger(__name__)
@@ -200,6 +201,8 @@ class AIReviewer:
         if not key or key.startswith("****"):
             raise ValueError("AIReviewer: invalid or masked api_key")
         bu = normalize_llm_base_url((base_url or "").strip() or None)
+        # H4 fix: 对非 HTTPS 的未知远程域名记录警告（不拦截）
+        validate_llm_base_url(bu)
         self._client = AsyncOpenAI(api_key=key, base_url=bu, timeout=timeout_seconds)
         self._model = (model_name or "").strip() or "gpt-4o-mini"
         self._base_url = bu

--- a/backend/app/llm_compat.py
+++ b/backend/app/llm_compat.py
@@ -2,40 +2,13 @@
 
 from __future__ import annotations
 
+import ipaddress
 import json
 import logging
 from typing import Any, Optional
 from urllib.parse import urlparse
 
 logger = logging.getLogger(__name__)
-
-# H4 fix: 已知 LLM 服务提供商域名白名单
-_KNOWN_LLM_PROVIDER_HOSTS: frozenset[str] = frozenset({
-    # OpenAI
-    "api.openai.com",
-    # 智谱 AI
-    "open.bigmodel.cn",
-    # DeepSeek
-    "api.deepseek.com",
-    # 月之暗面 / Kimi
-    "api.moonshot.cn",
-    # 阿里百炼
-    "dashscope.aliyuncs.com",
-    # 百度千帆
-    "aip.baidubce.com",
-    # Anthropic
-    "api.anthropic.com",
-    # Groq
-    "api.groq.com",
-    # 零一万物
-    "api.lingyiwanwu.com",
-    # 火山引擎 (字节)
-    "ark.cn-beijing.volces.com",
-    # SiliconFlow
-    "api.siliconflow.cn",
-    # Together AI
-    "api.together.xyz",
-})
 
 
 def normalize_llm_base_url(base_url: Optional[str]) -> Optional[str]:
@@ -51,10 +24,11 @@ def normalize_llm_base_url(base_url: Optional[str]) -> Optional[str]:
 
 
 def validate_llm_base_url(base_url: Optional[str]) -> None:
-    """H4 fix: 检查 LLM base_url 安全性，对非 HTTPS 的未知远程域名记录警告。
+    """Warn when a remote LLM base URL can expose the API key in transit.
 
-    仅记录 warning 日志，不拦截请求 — 尊重用户对本地工具的配置自主权。
-    后续可在前端保存配置时添加确认弹窗。
+    HTTP remains available for local model servers on loopback addresses. Remote
+    URLs are not blocked, but every non-HTTPS transport is logged regardless of
+    provider identity.
     """
     raw = (base_url or "").strip()
     if not raw:
@@ -63,23 +37,33 @@ def validate_llm_base_url(base_url: Optional[str]) -> None:
         raw = "http://" + raw
     try:
         parsed = urlparse(raw)
+        host = (parsed.hostname or "").lower()
     except ValueError:
         logger.warning("LLM base_url 解析失败: %r", base_url)
         return
-    host = (parsed.hostname or "").lower()
-    # localhost 不受限制
-    if host in ("localhost", "127.0.0.1", "::1") or host.endswith(".localhost"):
+
+    if parsed.scheme.lower() == "https":
         return
-    # 已知提供商域名始终允许
-    if host in _KNOWN_LLM_PROVIDER_HOSTS:
+    if host == "localhost" or host.endswith(".localhost"):
         return
-    # 未知的远程域名未使用 HTTPS 时记录警告
-    if parsed.scheme != "https":
-        logger.warning(
-            "LLM base_url '%s' 未使用 HTTPS，API Key 将以明文传输。"
-            "建议使用 HTTPS 或在提供商白名单中确认该域名。",
-            base_url,
-        )
+    try:
+        if ipaddress.ip_address(host).is_loopback:
+            return
+    except ValueError:
+        pass
+
+    logger.warning(
+        "LLM base_url '%s' 未使用 HTTPS，API Key 将以明文传输。"
+        "建议远程服务使用 HTTPS；HTTP 仅用于本机模型服务。",
+        base_url,
+    )
+
+
+def prepare_llm_base_url(base_url: Optional[str]) -> Optional[str]:
+    """Normalize and validate a base URL before constructing an LLM client."""
+    normalized = normalize_llm_base_url(base_url)
+    validate_llm_base_url(normalized)
+    return normalized
 
 
 def is_zhipu_glm_model(model: str, base_url: Optional[str]) -> bool:

--- a/backend/app/llm_compat.py
+++ b/backend/app/llm_compat.py
@@ -3,7 +3,39 @@
 from __future__ import annotations
 
 import json
+import logging
 from typing import Any, Optional
+from urllib.parse import urlparse
+
+logger = logging.getLogger(__name__)
+
+# H4 fix: 已知 LLM 服务提供商域名白名单
+_KNOWN_LLM_PROVIDER_HOSTS: frozenset[str] = frozenset({
+    # OpenAI
+    "api.openai.com",
+    # 智谱 AI
+    "open.bigmodel.cn",
+    # DeepSeek
+    "api.deepseek.com",
+    # 月之暗面 / Kimi
+    "api.moonshot.cn",
+    # 阿里百炼
+    "dashscope.aliyuncs.com",
+    # 百度千帆
+    "aip.baidubce.com",
+    # Anthropic
+    "api.anthropic.com",
+    # Groq
+    "api.groq.com",
+    # 零一万物
+    "api.lingyiwanwu.com",
+    # 火山引擎 (字节)
+    "ark.cn-beijing.volces.com",
+    # SiliconFlow
+    "api.siliconflow.cn",
+    # Together AI
+    "api.together.xyz",
+})
 
 
 def normalize_llm_base_url(base_url: Optional[str]) -> Optional[str]:
@@ -16,6 +48,38 @@ def normalize_llm_base_url(base_url: Optional[str]) -> Optional[str]:
         if raw.endswith(suffix):
             raw = raw[: -len(suffix)].rstrip("/")
     return raw or None
+
+
+def validate_llm_base_url(base_url: Optional[str]) -> None:
+    """H4 fix: 检查 LLM base_url 安全性，对非 HTTPS 的未知远程域名记录警告。
+
+    仅记录 warning 日志，不拦截请求 — 尊重用户对本地工具的配置自主权。
+    后续可在前端保存配置时添加确认弹窗。
+    """
+    raw = (base_url or "").strip()
+    if not raw:
+        return
+    if "://" not in raw:
+        raw = "http://" + raw
+    try:
+        parsed = urlparse(raw)
+    except ValueError:
+        logger.warning("LLM base_url 解析失败: %r", base_url)
+        return
+    host = (parsed.hostname or "").lower()
+    # localhost 不受限制
+    if host in ("localhost", "127.0.0.1", "::1") or host.endswith(".localhost"):
+        return
+    # 已知提供商域名始终允许
+    if host in _KNOWN_LLM_PROVIDER_HOSTS:
+        return
+    # 未知的远程域名未使用 HTTPS 时记录警告
+    if parsed.scheme != "https":
+        logger.warning(
+            "LLM base_url '%s' 未使用 HTTPS，API Key 将以明文传输。"
+            "建议使用 HTTPS 或在提供商白名单中确认该域名。",
+            base_url,
+        )
 
 
 def is_zhipu_glm_model(model: str, base_url: Optional[str]) -> bool:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -849,7 +849,9 @@ async def test_llm_connection():
 
     from openai import APIConnectionError, APIError, APITimeoutError, AsyncOpenAI, RateLimitError
 
-    bu = (llm.base_url or "").strip() or None
+    from .llm_compat import prepare_llm_base_url
+
+    bu = prepare_llm_base_url(llm.base_url)
     model = (llm.model or "").strip() or "gpt-4o-mini"
     try:
         client = AsyncOpenAI(api_key=api_key, base_url=bu, timeout=12.0)

--- a/backend/app/recording/ai_director.py
+++ b/backend/app/recording/ai_director.py
@@ -13,7 +13,7 @@ from openai import APIConnectionError, APIError, APITimeoutError, AsyncOpenAI, R
 from pydantic import BaseModel, Field, ValidationError, field_validator
 
 from ..env_utils import LLMConfig, llm_api_key_configured, llm_base_url_is_local_host, load_config, resolve_config_path
-from ..llm_compat import completion_extra_body, message_text, normalize_llm_base_url
+from ..llm_compat import completion_extra_body, message_text, prepare_llm_base_url
 from .normalizer import NormalizedRequest
 from .models import EventInfo
 
@@ -824,7 +824,7 @@ async def suggest_recording_outline(
         return _heuristic_outline(req), "heuristic", err
 
     model = (cfg_llm.model or "").strip() or "gpt-4o-mini"
-    base_url = normalize_llm_base_url(cfg_llm.base_url)
+    base_url = prepare_llm_base_url(cfg_llm.base_url)
     client = AsyncOpenAI(api_key=api_key, base_url=base_url, timeout=timeout_sec)
 
     user_msg = (

--- a/backend/tests/test_llm_compat.py
+++ b/backend/tests/test_llm_compat.py
@@ -1,5 +1,9 @@
+import logging
+
+import pytest
+
 from app.env_utils import LLMConfig
-from app.llm_compat import normalize_llm_base_url
+from app.llm_compat import normalize_llm_base_url, prepare_llm_base_url
 
 
 def test_normalize_strips_chat_completions():
@@ -13,3 +17,33 @@ def test_llm_config_validator():
         base_url="https://open.bigmodel.cn/api/paas/v4/chat/completions",
     )
     assert cfg.base_url == "https://open.bigmodel.cn/api/paas/v4"
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://api.openai.com/v1",
+        "http://custom-provider.example/v1",
+    ],
+)
+def test_prepare_warns_for_any_remote_http_url(url, caplog):
+    with caplog.at_level(logging.WARNING, logger="app.llm_compat"):
+        assert prepare_llm_base_url(url) == url
+
+    assert "API Key 将以明文传输" in caplog.text
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://localhost:11434/v1",
+        "http://127.0.0.2:11434/v1",
+        "http://[::1]:11434/v1",
+        "https://custom-provider.example/v1",
+    ],
+)
+def test_prepare_allows_https_and_loopback_http_without_warning(url, caplog):
+    with caplog.at_level(logging.WARNING, logger="app.llm_compat"):
+        assert prepare_llm_base_url(url) == url
+
+    assert "API Key 将以明文传输" not in caplog.text


### PR DESCRIPTION
## 修复内容
- 所有 `AsyncOpenAI` client 统一通过 `prepare_llm_base_url()` 标准化并校验服务地址。
- 远程服务使用非 HTTPS 时记录 warning；localhost 和 loopback 地址仍允许使用 HTTP。

## 验证
- 8 个远程、HTTPS 和 loopback URL 回归测试通过。
