### PR TITLE
perf(parser): share demo facts across player analysis

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1449,8 +1449,8 @@ class ParseMultiRequest(BaseModel):
 
 @app.post("/api/demo/parse-multi")
 async def parse_demo_multi(req: ParseMultiRequest, filename: str):
-    """多玩家解析：对同一个 Demo 依次分析每个目标玩家，返回 { players: { name: result } }。"""
-    from .demo_parse_isolation import IsolatedParseError
+    """多玩家解析：共享同一次 Demo 扫描，返回 { players: { name: result } }。"""
+    from .demo_parse_isolation import IsolatedParseError, analyze_multi_isolated
 
     dem_path = UPLOAD_DIR / filename
     if not dem_path.exists():
@@ -1458,15 +1458,13 @@ async def parse_demo_multi(req: ParseMultiRequest, filename: str):
 
     cfg = load_config()
 
-    results_by_player: dict = {}
     try:
-        for player in req.target_players:
-            results_by_player[player] = await asyncio.to_thread(
-                _analyze_demo_sync,
-                str(dem_path),
-                player,
-                req.freeze_to_death_rounds,
-            )
+        results_by_player = await asyncio.to_thread(
+            analyze_multi_isolated,
+            str(dem_path),
+            req.target_players,
+            req.freeze_to_death_rounds,
+        )
     except IsolatedParseError as e:
         raise HTTPException(500, f"Demo 解析失败：{e}") from e
 

--- a/backend/app/parser/analyzer.py
+++ b/backend/app/parser/analyzer.py
@@ -4,7 +4,7 @@ import logging
 import os
 import uuid
 from bisect import bisect_left, bisect_right
-from dataclasses import replace
+from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Any, Optional
 
@@ -30,14 +30,14 @@ from .parse_utils import (
     _DEMOPARSER_RE_RAISE, _bool, _int, _max_demo_tick,
     _duration_mins_from_tick_span, _get_match_start_tick,
     _count_team_wins_from_round_end_df, _infer_total_rounds_from_round_end,
-    win_panel_ceiling_from_match_tick,
+    _pick_assister_column, win_panel_ceiling_from_match_tick,
 )
 from .round_economy import (
     build_round_economy, build_round_economy_shared, extract_target_team_map,
     build_round_scores, build_round_scores_team_based,
     _scoreline_by_starting_roster, _extract_team_names_from_demo,
     build_group_side_by_round, round_target_team_map_from_groups,
-    compute_team_identity_scoreline,
+    compute_team_identity_scoreline, _round_end_frame_usable,
 )
 from .player_roster import (
     build_player_name_to_user_id, build_player_name_to_steam_id,
@@ -64,6 +64,35 @@ from .clip_builder import (
 from .spatial_analysis import build_fire_index, count_shots_before
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class SharedDemoFacts:
+    """Player-independent analysis facts materialized once per Demo.
+
+    The native parser is intentionally kept out of the per-player finish path.
+    Mutable values are treated as read-only; player-specific builders copy the
+    small structures they need before applying any corrections.
+    """
+
+    match_summary: tuple[int, int, str, int, str, str]
+    demo_max_tick: int
+    name_to_uid: dict[str, int]
+    observed_user_ids: tuple[int, ...]
+    spec_slots: dict[str, int]
+    name_to_sid: dict[str, int]
+    all_players_roster: list[dict]
+    server_name: str
+    round_scores_by_round: dict[int, dict[int, int]]
+    victim_blind_index: dict[str, list[tuple[int, float]]]
+    grenade_detonate_points: list[tuple[int, float, float]]
+    bomb_explode_tick_map: dict[int, int]
+    round_end_tick_map: dict[int, int]
+    timeline_event_positions_by_player: dict[str, tuple[int, ...]]
+
+    def roster_snapshot(self) -> list[dict]:
+        """Return an isolated roster for one ParseResult output."""
+        return [dict(player) for player in self.all_players_roster]
 
 
 def _world_self_kill_cluster_c4_surrogate_keys(
@@ -145,9 +174,21 @@ class DemoAnalyzer:
         except Exception:
             return "unknown"
 
-    def _build_match_summary(self, match_start_tick: int) -> tuple[int, int, str, int, str, str]:
+    def _build_match_summary(
+        self,
+        match_start_tick: int,
+        *,
+        death_events: Optional[pd.DataFrame] = None,
+        round_end_df: Optional[pd.DataFrame] = None,
+        header: Optional[dict] = None,
+    ) -> tuple[int, int, str, int, str, str]:
         ta, tb, md, dm, _, tan, tbn = collect_match_summary_metrics(
-            self.parser, self.dem_path, match_start_tick,
+            self.parser,
+            self.dem_path,
+            match_start_tick,
+            death_events=death_events,
+            round_end_df=round_end_df,
+            header=header,
         )
         return ta, tb, md, dm, tan, tbn
 
@@ -208,7 +249,7 @@ class DemoAnalyzer:
         # player_death (largest event) — player=["X","Y","Z"] 附带攻击者/受害者击杀瞬间坐标
         _death_other = list(dict.fromkeys(list(_EXTRA_EVENT_FIELDS) + list(_PLAYER_DEATH_GAME_KEYS)))
         events = _filter_ms(_to_pandas_df(self.parser.parse_event(
-            "player_death", other=_death_other, player=["X", "Y", "Z"],
+            "player_death", other=_death_other, player=["X", "Y", "Z", "user_id"],
         )))
 
         # weapon_fire + player_hurt — 合并为单次 demo 扫描
@@ -240,6 +281,25 @@ class DemoAnalyzer:
         round_start_df  = _round_batch["round_start"]
         match_start_df  = _round_batch["round_announce_match_start"]
 
+        # A failed batch parse is represented as empty frames. Empty critical
+        # round data is not authoritative: retry the legacy single-event paths
+        # so a transient/format-specific batch failure cannot erase scores,
+        # round boundaries, or duration metadata.
+        if not _round_end_frame_usable(re_df, match_start_tick):
+            re_df = self._safe_parse_event(
+                "round_end",
+                other=list(_EXTRA_EVENT_FIELDS) + ["winner", "reason"],
+            )
+        if freeze_end_df.empty:
+            freeze_end_df = self._safe_parse_event(
+                "round_freeze_end",
+                other=list(_EXTRA_EVENT_FIELDS),
+            )
+        if round_start_df.empty:
+            round_start_df = self._safe_parse_event("round_start")
+        if match_start_df.empty:
+            match_start_df = self._safe_parse_event("round_announce_match_start")
+
         if match_start_tick > 0 and not re_df.empty and "tick" in re_df.columns:
             re_df = re_df.loc[
                 pd.to_numeric(re_df["tick"], errors="coerce").fillna(0).astype(int) >= match_start_tick
@@ -268,10 +328,23 @@ class DemoAnalyzer:
 
         # 可靠的队伍身份（parse_player_info）+ 每回合阵营表：作为逐 tick team_num 失效
         # （部分国服 demo）时的兜底来源，用于队伍分组、胜负与比分。
-        steam_to_final_team_shared = build_steam_to_team_from_player_info(self.parser)
-        name_to_final_team_shared = build_name_to_team_from_player_info(self.parser)
+        try:
+            player_info_df = _to_pandas_df(self.parser.parse_player_info())
+        except BaseException as e:
+            if isinstance(e, _DEMOPARSER_RE_RAISE):
+                raise
+            player_info_df = pd.DataFrame()
+        steam_to_final_team_shared = build_steam_to_team_from_player_info(
+            self.parser, player_info_df=player_info_df,
+        )
+        name_to_final_team_shared = build_name_to_team_from_player_info(
+            self.parser, player_info_df=player_info_df,
+        )
         group_side_by_round_shared = build_group_side_by_round(
-            self.parser, round_freeze_end_ticks_shared, steam_to_final_team_shared,
+            self.parser,
+            round_freeze_end_ticks_shared,
+            steam_to_final_team_shared,
+            player_ticks_df=economy_ticks_df,
         )
 
         # Name strip on all relevant DataFrames
@@ -322,7 +395,195 @@ class DemoAnalyzer:
             "steam_to_final_team_shared":    steam_to_final_team_shared,
             "name_to_final_team_shared":     name_to_final_team_shared,
             "group_side_by_round_shared":    group_side_by_round_shared,
+            "player_info_df":                 player_info_df,
         }
+
+    def _build_shared_demo_facts(
+        self,
+        *,
+        match_start_tick: int,
+        header: dict,
+        shared_events: dict,
+        expected_players: Optional[list[str]] = None,
+    ) -> SharedDemoFacts:
+        """Materialize native-parser and full-table facts once for all players."""
+        events = shared_events["events"]
+        re_df = shared_events["re_df_cached"]
+
+        match_summary = self._build_match_summary(
+            match_start_tick,
+            death_events=events,
+            round_end_df=re_df,
+            header=header,
+        )
+        demo_max_tick = _max_demo_tick(
+            self.parser,
+            re_df,
+            match_start_tick,
+            death_df=events,
+        )
+        name_to_uid = build_player_name_to_user_id(
+            self.parser,
+            match_start_tick,
+            death_events=events,
+        )
+        name_to_sid = build_player_name_to_steam_id(
+            self.parser,
+            match_start_tick,
+            death_events=events,
+        )
+        roster_tick = (
+            match_start_tick
+            if match_start_tick > 0
+            else max(
+                1,
+                _int(events["tick"].min())
+                if events.shape[0] > 0 and "tick" in events.columns
+                else 1,
+            )
+        )
+        expected_roster_names = (
+            set(expected_players or ())
+            | set(name_to_uid)
+            | set(name_to_sid)
+            | set(shared_events.get("name_to_final_team_shared") or {})
+        )
+        roster_ticks_df = shared_events.get("economy_ticks_df")
+        observed_user_ids = tuple(name_to_uid.values())
+        spec_slots = build_player_name_to_spec_player_slot_dict(
+            self.parser,
+            roster_tick,
+            self.dem_path,
+            player_ticks_df=roster_ticks_df,
+            expected_names=expected_roster_names,
+        )
+        all_players_roster = _build_all_players_roster(
+            self.parser,
+            match_start_tick,
+            spec_slots,
+            name_to_sid,
+            name_to_team_pi=shared_events.get("name_to_final_team_shared") or {},
+            player_ticks_df=roster_ticks_df,
+            expected_names=expected_roster_names,
+        )
+        server_name = str(header.get("server_name") or "").strip()
+        round_scores_by_round = build_round_scores(
+            self.parser,
+            match_start_tick,
+            re_df=re_df,
+        )
+
+        victim_blind_index: dict[str, list[tuple[int, float]]] = {}
+        blind_df = shared_events.get("blind_df")
+        if blind_df is not None and not blind_df.empty:
+            duration_col = next(
+                (c for c in ("blind_duration", "duration") if c in blind_df.columns),
+                None,
+            )
+            victim_col = "user_name" if "user_name" in blind_df.columns else None
+            if duration_col and victim_col:
+                for _, row in blind_df.iterrows():
+                    name = str(row.get(victim_col) or "").strip()
+                    tick = _int(row.get("tick"))
+                    try:
+                        duration = float(row.get(duration_col) or 0.0)
+                    except (TypeError, ValueError):
+                        duration = 0.0
+                    if name and tick > 0:
+                        victim_blind_index.setdefault(name, []).append((tick, duration))
+                for name in victim_blind_index:
+                    victim_blind_index[name].sort()
+
+        grenade_detonate_points: list[tuple[int, float, float]] = []
+        for grenade_df in shared_events["nade_batch"].values():
+            if grenade_df.empty:
+                continue
+            xcol = "x" if "x" in grenade_df.columns else (
+                "X" if "X" in grenade_df.columns else None
+            )
+            ycol = "y" if "y" in grenade_df.columns else (
+                "Y" if "Y" in grenade_df.columns else None
+            )
+            if xcol is None or ycol is None:
+                continue
+            for _, row in grenade_df.iterrows():
+                try:
+                    grenade_detonate_points.append(
+                        (_int(row.get("tick")), float(row.get(xcol)), float(row.get(ycol)))
+                    )
+                except (TypeError, ValueError):
+                    pass
+        grenade_detonate_points.sort()
+
+        bomb_explode_tick_map: dict[int, int] = {}
+        bomb_exploded_df = shared_events["bomb_exploded_df"]
+        if (
+            not bomb_exploded_df.empty
+            and "tick" in bomb_exploded_df.columns
+            and "total_rounds_played" in bomb_exploded_df.columns
+        ):
+            for _, row in bomb_exploded_df.iterrows():
+                tick = _int(row.get("tick"))
+                round_number = _int(row.get("total_rounds_played")) + 1
+                if tick > 0 and round_number > 0 and round_number not in bomb_explode_tick_map:
+                    bomb_explode_tick_map[round_number] = tick
+
+        round_end_tick_map: dict[int, int] = {}
+        if not re_df.empty and "tick" in re_df.columns:
+            sequence = 0
+            for _, row in re_df.sort_values("tick", kind="mergesort").iterrows():
+                tick = _int(row.get("tick"))
+                rounds_played = row.get("total_rounds_played")
+                if rounds_played is not None and not (
+                    isinstance(rounds_played, float) and pd.isna(rounds_played)
+                ):
+                    try:
+                        round_number = int(float(rounds_played))
+                    except (ValueError, TypeError):
+                        sequence += 1
+                        round_number = sequence
+                else:
+                    sequence += 1
+                    round_number = sequence
+                if tick > 0 and round_number > 0 and round_number not in round_end_tick_map:
+                    round_end_tick_map[round_number] = tick
+
+        timeline_positions: dict[str, list[int]] = {}
+        assist_col = _pick_assister_column(events) if not events.empty else None
+        for position, (_, row) in enumerate(events.iterrows()):
+            attacker = str(row.get("attacker_name", "") or "").strip()
+            victim = str(row.get("user_name", "") or "").strip()
+            if not victim and "player_name" in row:
+                victim = str(row.get("player_name", "") or "").strip()
+            assister = ""
+            if assist_col:
+                raw_assister = row.get(assist_col, "")
+                if not pd.isna(raw_assister):
+                    assister = str(raw_assister).strip()
+                    if assister.lower() in ("nan", "nat", "none"):
+                        assister = ""
+            for name in {attacker, victim, assister}:
+                if name:
+                    timeline_positions.setdefault(name, []).append(position)
+
+        return SharedDemoFacts(
+            match_summary=match_summary,
+            demo_max_tick=demo_max_tick,
+            name_to_uid=name_to_uid,
+            observed_user_ids=observed_user_ids,
+            spec_slots=spec_slots,
+            name_to_sid=name_to_sid,
+            all_players_roster=all_players_roster,
+            server_name=server_name,
+            round_scores_by_round=round_scores_by_round,
+            victim_blind_index=victim_blind_index,
+            grenade_detonate_points=grenade_detonate_points,
+            bomb_explode_tick_map=bomb_explode_tick_map,
+            round_end_tick_map=round_end_tick_map,
+            timeline_event_positions_by_player={
+                name: tuple(positions) for name, positions in timeline_positions.items()
+            },
+        )
 
     def analyze_multi_players(
         self,
@@ -347,11 +608,22 @@ class DemoAnalyzer:
         if not players:
             return {}
 
-        map_name = self._detect_map()
+        try:
+            parsed_header = self.parser.parse_header()
+            header = parsed_header if isinstance(parsed_header, dict) else {}
+        except Exception:
+            header = {}
+        map_name = str(header.get("map_name") or "unknown")
         match_start_tick = _get_match_start_tick(self.parser)
 
         # Phase 1: Parse all shared events ONCE
         _shared = self._parse_shared_events(match_start_tick)
+        shared_facts = self._build_shared_demo_facts(
+            match_start_tick=match_start_tick,
+            header=header,
+            shared_events=_shared,
+            expected_players=players,
+        )
 
         # Phase 2: Per-player first pass (round economy + kill/death extraction, pure Python after events)
         aim_secs = _backstab_aim_sample_offsets_sec()
@@ -653,6 +925,7 @@ class DemoAnalyzer:
                 re_df_cached=_shared["re_df_cached"],
                 win_panel_match_tick=_shared["win_panel_match_tick"],
                 blind_df=_shared["blind_df"],
+                shared_facts=shared_facts,
                 freeze_to_death_rounds=freeze_to_death_rounds,
             )
 
@@ -689,6 +962,7 @@ class DemoAnalyzer:
         re_df_cached: "pd.DataFrame",
         win_panel_match_tick: int = 0,
         blind_df: "Optional[pd.DataFrame]" = None,
+        shared_facts: SharedDemoFacts,
         freeze_to_death_rounds: "Optional[list[int]]" = None,
     ) -> "ParseResult":
         bomb_highlights = analyze_bomb_defuse_highlights(
@@ -699,25 +973,7 @@ class DemoAnalyzer:
         enrich_kill_action_tags_spatial(round_kills, spatial_cache, target_player)
 
         # 好闪配好人质量门控：从 blind_df 查受害者盲化时长，< 阈值则移除 tag
-        _victim_blind_index: dict[str, list[tuple[int, float]]] = {}
-        if blind_df is not None and not blind_df.empty:
-            _dur_col = next(
-                (c for c in ("blind_duration", "duration") if c in blind_df.columns),
-                None,
-            )
-            _vname_col = "user_name" if "user_name" in blind_df.columns else None
-            if _dur_col and _vname_col:
-                for _, _brow in blind_df.iterrows():
-                    _bname = str(_brow.get(_vname_col) or "").strip()
-                    _btick = _int(_brow.get("tick"))
-                    try:
-                        _bdur = float(_brow.get(_dur_col) or 0.0)
-                    except (TypeError, ValueError):
-                        _bdur = 0.0
-                    if _bname and _btick > 0:
-                        _victim_blind_index.setdefault(_bname, []).append((_btick, _bdur))
-                for _vn in _victim_blind_index:
-                    _victim_blind_index[_vn].sort()
+        _victim_blind_index = shared_facts.victim_blind_index
 
         _FLASH_WINDOW_TICKS = int(TICK_RATE * 3.0)
         for _kills in round_kills.values():
@@ -742,78 +998,13 @@ class DemoAnalyzer:
         # ── 额外辅助事件 ──
 
         # player_blind — use pre-parsed shared DataFrame (already warmup-filtered, user_name stripped)
-        flash_on_target_index: list[tuple[int, float]] = []
-        try:
-            _bdf_src = blind_df if (blind_df is not None and not blind_df.empty) else pd.DataFrame()
-            if not _bdf_src.empty and "user_name" in _bdf_src.columns:
-                bdf = _bdf_src.loc[_bdf_src["user_name"] == target_player]
-                dur_col = None
-                for _c in ("blind_duration", "duration"):
-                    if _c in bdf.columns:
-                        dur_col = _c
-                        break
-                for _, _br in bdf.iterrows():
-                    _bt = _int(_br.get("tick"))
-                    _bd = 0.0
-                    if dur_col is not None:
-                        try:
-                            _bd = float(_br.get(dur_col) or 0.0)
-                        except (TypeError, ValueError):
-                            _bd = 0.0
-                    if _bt > 0:
-                        flash_on_target_index.append((_bt, _bd))
-                flash_on_target_index.sort()
-        except Exception:
-            flash_on_target_index = []
+        flash_on_target_index = list(_victim_blind_index.get(target_player, ()))
 
-        # 手雷爆点（已从批量结果中读取）
-        grenade_detonate_points: list[tuple[int, float, float]] = []
-        for _ev, _gdf in nade_batch.items():
-            if _gdf.empty:
-                continue
-            xcol = "x" if "x" in _gdf.columns else ("X" if "X" in _gdf.columns else None)
-            ycol = "y" if "y" in _gdf.columns else ("Y" if "Y" in _gdf.columns else None)
-            if xcol is None or ycol is None:
-                continue
-            for _, _gr in _gdf.iterrows():
-                try:
-                    grenade_detonate_points.append((
-                        _int(_gr.get("tick")),
-                        float(_gr.get(xcol)),
-                        float(_gr.get(ycol)),
-                    ))
-                except (TypeError, ValueError):
-                    pass
-        grenade_detonate_points.sort()
+        grenade_detonate_points = shared_facts.grenade_detonate_points
 
-        # bomb_explode_tick_map（已从批量结果中读取）
-        bomb_explode_tick_map: dict[int, int] = {}
-        _be = bomb_exploded_df
-        if not _be.empty and "tick" in _be.columns and "total_rounds_played" in _be.columns:
-            for _, _br in _be.iterrows():
-                _bt = _int(_br.get("tick"))
-                _rn = _int(_br.get("total_rounds_played")) + 1
-                if _bt > 0 and _rn > 0 and _rn not in bomb_explode_tick_map:
-                    bomb_explode_tick_map[_rn] = _bt
+        bomb_explode_tick_map = shared_facts.bomb_explode_tick_map
 
-        # round_end_tick_map — 复用 _parse_shared_events 缓存的 round_end DataFrame
-        round_end_tick_map: dict[int, int] = {}
-        if not re_df_cached.empty and "tick" in re_df_cached.columns:
-            _seq = 0
-            for _, _rr in re_df_cached.sort_values("tick", kind="mergesort").iterrows():
-                _rt = _int(_rr.get("tick"))
-                _trc = _rr.get("total_rounds_played")
-                if _trc is not None and not (isinstance(_trc, float) and pd.isna(_trc)):
-                    try:
-                        _rn = int(float(_trc))
-                    except (ValueError, TypeError):
-                        _seq += 1
-                        _rn = _seq
-                else:
-                    _seq += 1
-                    _rn = _seq
-                if _rt > 0 and _rn > 0 and _rn not in round_end_tick_map:
-                    round_end_tick_map[_rn] = _rt
+        round_end_tick_map = shared_facts.round_end_tick_map
 
         # 回合末刀杀分离
         _transition_knife_highlight_kills: list[dict] = []
@@ -1275,8 +1466,7 @@ class DemoAnalyzer:
         )
         fail_clips = fail_clips + shoulder_clips
 
-        # _demo_max_tick 使用缓存的 round_end DataFrame
-        _demo_max_tick = _max_demo_tick(self.parser, re_df_cached, match_start_tick)
+        _demo_max_tick = shared_facts.demo_max_tick
 
         compilation_clips = build_rival_compilations(
             target_player, round_kills, death_records,
@@ -1444,20 +1634,17 @@ class DemoAnalyzer:
             )
 
         team_a_score, team_b_score, match_date, duration_mins, team_a_name, team_b_name = (
-            self._build_match_summary(match_start_tick)
+            shared_facts.match_summary
         )
 
-        name_to_uid = build_player_name_to_user_id(self.parser, match_start_tick)
-        roster_tick = (
-            match_start_tick
-            if match_start_tick > 0
-            else max(1, _int(events["tick"].min()) if events.shape[0] > 0 and "tick" in events.columns else 1)
-        )
-        observed_user_ids = tuple(name_to_uid.values())
-        event_user_id = _lookup_user_id_for_name(name_to_uid, target_player)
-        spec_slots = build_player_name_to_spec_player_slot_dict(self.parser, roster_tick, self.dem_path)
+        event_user_id = _lookup_user_id_for_name(shared_facts.name_to_uid, target_player)
+        spec_slots = shared_facts.spec_slots
         target_player_user_id = (
-            _spec_player_slot_from_event_user_id(event_user_id, self.dem_path, observed_user_ids)
+            _spec_player_slot_from_event_user_id(
+                event_user_id,
+                self.dem_path,
+                shared_facts.observed_user_ids,
+            )
             or lookup_spec_player_slot_for_name(spec_slots, target_player)
         )
         for _c in clips:
@@ -1467,19 +1654,11 @@ class DemoAnalyzer:
             if _c.killer_name:
                 _c.killer_spec_slot = spec_slots.get(_c.killer_name.lower())
             _c.killers_spec_slots = [spec_slots.get(k.lower()) if k else None for k in _c.killers]
-        name_to_sid = build_player_name_to_steam_id(self.parser, match_start_tick)
-        tsid = _lookup_steam_id_for_name(name_to_sid, target_player)
+        tsid = _lookup_steam_id_for_name(shared_facts.name_to_sid, target_player)
         target_steam_id = str(tsid) if tsid is not None else None
 
-        all_players_roster = _build_all_players_roster(self.parser, match_start_tick, spec_slots, name_to_sid)
-
-        _server_name = ""
-        try:
-            _hdr = self.parser.parse_header()
-            _sn_raw = _hdr.get("server_name") if isinstance(_hdr, dict) else None
-            _server_name = str(_sn_raw).strip() if _sn_raw is not None else ""
-        except Exception:
-            pass
+        all_players_roster = shared_facts.roster_snapshot()
+        _server_name = shared_facts.server_name
 
         total_rounds = max(round_kills.keys(), default=0)
         if events.shape[0] > 0 and "total_rounds_played" in events.columns:
@@ -1503,13 +1682,18 @@ class DemoAnalyzer:
 
             # 每回合比分：优先按「队伍身份」累计（与记分牌一致，换边不串号），
             # 回退到旧的按阵营 (T/CT) 累计。槽位约定：2=开赛打 T 的一方，3=开赛打 CT 的一方。
-            round_scores_tbl = build_round_scores(self.parser, match_start_tick)
+            round_scores_tbl = shared_facts.round_scores_by_round
             if round_team_score_map and tteam in (2, 3):
                 _opp_slot = 3 if tteam == 2 else 2
                 round_scores_tbl = {
                     rn: {tteam: int(own), _opp_slot: int(opp)}
                     for rn, (own, opp) in round_team_score_map.items()
                 }
+            timeline_positions = shared_facts.timeline_event_positions_by_player.get(
+                target_player,
+                (),
+            )
+            timeline_events = events.iloc[list(timeline_positions)]
             bundle = build_round_timeline(
                 demo_path=str(self.dem_path),
                 map_name=map_name,
@@ -1518,7 +1702,7 @@ class DemoAnalyzer:
                 target_steam_id=target_steam_id,
                 target_team_num=tteam,
                 round_target_team_map=round_target_team_map or {},
-                events=events,
+                events=timeline_events,
                 round_freeze_end_ticks=round_freeze_end_ticks,
                 round_result_map=round_result_map,
                 round_scores_by_round=round_scores_tbl,
@@ -1577,6 +1761,10 @@ def collect_match_summary_metrics(
     parser: DemoParser,
     dem_path: Path,
     match_start_tick: int,
+    *,
+    death_events: Optional[pd.DataFrame] = None,
+    round_end_df: Optional[pd.DataFrame] = None,
+    header: Optional[dict] = None,
 ) -> tuple[int, int, str, int, int, str, str]:
     """全局比赛信息：Team2/3 胜场、Demo 时长、总回合、队名。"""
     team_a_score = 0
@@ -1591,8 +1779,8 @@ def collect_match_summary_metrics(
 
     duration_header = 0
     try:
-        header = parser.parse_header()
-        raw_pt = header.get("playback_time", 0)
+        header_data = header if header is not None else parser.parse_header()
+        raw_pt = header_data.get("playback_time", 0)
         duration_header = int(float(raw_pt) // 60) if raw_pt is not None else 0
     except BaseException as e:
         if isinstance(e, (KeyboardInterrupt, SystemExit, GeneratorExit)):
@@ -1600,7 +1788,11 @@ def collect_match_summary_metrics(
         duration_header = 0
 
     try:
-        re_df = _to_pandas_df(parser.parse_event("round_end"))
+        re_df = (
+            round_end_df
+            if _round_end_frame_usable(round_end_df, match_start_tick)
+            else _to_pandas_df(parser.parse_event("round_end"))
+        )
     except BaseException as e:
         if isinstance(e, (KeyboardInterrupt, SystemExit, GeneratorExit)):
             raise
@@ -1637,7 +1829,12 @@ def collect_match_summary_metrics(
     if total_rounds_est <= 0:
         total_rounds_est = _infer_total_rounds_from_round_end(re_df, match_start_tick)
 
-    max_tick = _max_demo_tick(parser, re_df, match_start_tick)
+    max_tick = _max_demo_tick(
+        parser,
+        re_df,
+        match_start_tick,
+        death_df=death_events,
+    )
     duration_ticks = _duration_mins_from_tick_span(match_start_tick, max_tick)
     duration_mins = max(duration_header, duration_ticks)
 

--- a/backend/app/parser/parse_utils.py
+++ b/backend/app/parser/parse_utils.py
@@ -14,6 +14,12 @@ logger = logging.getLogger(__name__)
 # demoparser2 在坏/不兼容 demo 上可能 Rust panic → PyO3 的 PanicException 不是 Exception 子类。
 _DEMOPARSER_RE_RAISE = (KeyboardInterrupt, SystemExit, GeneratorExit)
 
+# `team_num` is normally the convenient player-pawn alias exposed by
+# demoparser2.  Some Perfect World demos omit the pawn value for a subset of
+# players while the controller still carries the authoritative team number.
+PLAYER_CONTROLLER_TEAM_PROP = "CCSPlayerController.m_iTeamNum"
+PLAYER_TEAM_PARSE_FIELDS = ["team_num", PLAYER_CONTROLLER_TEAM_PROP]
+
 
 def win_panel_ceiling_from_match_tick(
     win_panel_match_tick: int, tick_rate: float
@@ -41,6 +47,27 @@ def _to_pandas_df(result) -> pd.DataFrame:
     if isinstance(result, list):
         return pd.DataFrame(result) if result else pd.DataFrame()
     return pd.DataFrame()
+
+
+def coalesce_player_team_num(df: pd.DataFrame) -> pd.DataFrame:
+    """Fill missing/invalid ``team_num`` values from the player controller.
+
+    The fallback is deterministic and stays within the same ``parse_ticks``
+    result, so callers gain compatibility without an additional demo scan.
+    """
+    if df.empty or PLAYER_CONTROLLER_TEAM_PROP not in df.columns:
+        return df
+    controller = pd.to_numeric(df[PLAYER_CONTROLLER_TEAM_PROP], errors="coerce")
+    controller = controller.where(controller.isin((2, 3)))
+    if "team_num" in df.columns:
+        primary = pd.to_numeric(df["team_num"], errors="coerce")
+        primary = primary.where(primary.isin((2, 3)))
+        combined = primary.fillna(controller)
+    else:
+        combined = controller
+    out = df.copy()
+    out["team_num"] = combined
+    return out
 
 
 def _safe_parse_event(parser: DemoParser, event_name: str, **kwargs) -> pd.DataFrame:
@@ -290,14 +317,24 @@ def _steam_id_cell(val) -> Optional[int]:
     return i
 
 
-def _max_demo_tick(parser: DemoParser, re_df: pd.DataFrame, match_start_tick: int) -> int:
+def _max_demo_tick(
+    parser: DemoParser,
+    re_df: pd.DataFrame,
+    match_start_tick: int,
+    *,
+    death_df: Optional[pd.DataFrame] = None,
+) -> int:
     mx = 0
     if not re_df.empty and "tick" in re_df.columns:
         v = pd.to_numeric(re_df["tick"], errors="coerce").max()
         if not pd.isna(v):
             mx = max(mx, int(v))
     try:
-        de = _to_pandas_df(parser.parse_event("player_death"))
+        de = (
+            death_df
+            if death_df is not None and not death_df.empty and "tick" in death_df.columns
+            else _to_pandas_df(parser.parse_event("player_death"))
+        )
         if not de.empty and "tick" in de.columns:
             if match_start_tick > 0:
                 de = de.loc[

--- a/backend/app/parser/player_roster.py
+++ b/backend/app/parser/player_roster.py
@@ -11,6 +11,8 @@ from .parse_utils import (
     _to_pandas_df,
     _cell_str,
     _cell_team,
+    PLAYER_TEAM_PARSE_FIELDS,
+    coalesce_player_team_num,
     _user_id_cell,
     _steam_id_cell,
     _pick_assister_column,
@@ -33,7 +35,11 @@ def _player_info_team_col(pi: pd.DataFrame) -> Optional[str]:
     return next((c for c in ("team_number", "team_num", "team") if c in pi.columns), None)
 
 
-def build_steam_to_team_from_player_info(parser: DemoParser) -> dict[str, int]:
+def build_steam_to_team_from_player_info(
+    parser: DemoParser,
+    *,
+    player_info_df: Optional[pd.DataFrame] = None,
+) -> dict[str, int]:
     """steamid64(str) -> 末段（第二阶段）队伍号 2/3，来自 parse_player_info。
 
     parse_player_info 是最可靠的全员队伍来源：即便逐 tick 的 team_num 字段在某些
@@ -41,7 +47,11 @@ def build_steam_to_team_from_player_info(parser: DemoParser) -> dict[str, int]:
     用作稳定的「队伍身份」分组键（两支 5 人队整局不变，换边只改阵营号）。
     """
     try:
-        pi = _to_pandas_df(parser.parse_player_info())
+        pi = (
+            player_info_df
+            if player_info_df is not None
+            else _to_pandas_df(parser.parse_player_info())
+        )
     except BaseException as e:
         if isinstance(e, _DEMOPARSER_RE_RAISE):
             raise
@@ -61,10 +71,18 @@ def build_steam_to_team_from_player_info(parser: DemoParser) -> dict[str, int]:
     return out
 
 
-def build_name_to_team_from_player_info(parser: DemoParser) -> dict[str, int]:
+def build_name_to_team_from_player_info(
+    parser: DemoParser,
+    *,
+    player_info_df: Optional[pd.DataFrame] = None,
+) -> dict[str, int]:
     """玩家名(小写) -> 末段队伍号 2/3，来自 parse_player_info（剔除 bot/观察者）。"""
     try:
-        pi = _to_pandas_df(parser.parse_player_info())
+        pi = (
+            player_info_df
+            if player_info_df is not None
+            else _to_pandas_df(parser.parse_player_info())
+        )
     except BaseException as e:
         if isinstance(e, _DEMOPARSER_RE_RAISE):
             raise
@@ -137,8 +155,8 @@ def _build_tick_team_lookup(parser: DemoParser, ticks: list[int]) -> dict[int, d
         return {}
     uniq = sorted({int(t) for t in ticks})
     try:
-        raw = parser.parse_ticks(["team_num", "name"], ticks=uniq)
-        df = _to_pandas_df(raw)
+        raw = parser.parse_ticks(PLAYER_TEAM_PARSE_FIELDS + ["name"], ticks=uniq)
+        df = coalesce_player_team_num(_to_pandas_df(raw))
     except BaseException as e:
         if isinstance(e, _DEMOPARSER_RE_RAISE):
             raise
@@ -176,31 +194,66 @@ def _lookup_team_at_tick(
     return None
 
 
-def build_player_name_to_user_id(parser: DemoParser, match_start_tick: int) -> dict[str, int]:
+def _player_tick_snapshot_at(
+    df: Optional[pd.DataFrame],
+    desired_tick: int,
+) -> pd.DataFrame:
+    """Reuse a materialized player snapshot only when its tick is exact."""
+    if df is None or df.empty:
+        return pd.DataFrame()
+    work = coalesce_player_team_num(df)
+    if "tick" not in work.columns:
+        return pd.DataFrame()
+    numeric_ticks = pd.to_numeric(work["tick"], errors="coerce")
+    exact = work.loc[numeric_ticks == int(desired_tick)]
+    return exact.copy() if not exact.empty else pd.DataFrame()
+
+
+def build_player_name_to_user_id(
+    parser: DemoParser,
+    match_start_tick: int,
+    *,
+    death_events: Optional[pd.DataFrame] = None,
+) -> dict[str, int]:
     """从 player_death 的 user_id 扩展字段建立「昵称 -> 引擎 user id」。"""
+    def _mapping(frame: pd.DataFrame) -> tuple[dict[str, int], set[str]]:
+        if frame.empty:
+            return {}, set()
+        work = frame
+        if match_start_tick > 0 and "tick" in work.columns:
+            work = work.loc[
+                pd.to_numeric(work["tick"], errors="coerce").fillna(0).astype(int)
+                >= match_start_tick
+            ]
+        out: dict[str, int] = {}
+        expected: set[str] = set()
+        for _, row in work.iterrows():
+            vn = _cell_str(row.get("user_name"))
+            vu = _user_id_cell(row.get("user_user_id"))
+            if vn:
+                expected.add(vn.lower())
+                if vu is not None:
+                    out[vn] = vu
+            an = _cell_str(row.get("attacker_name"))
+            au = _user_id_cell(row.get("attacker_user_id"))
+            if an:
+                expected.add(an.lower())
+                if au is not None:
+                    out[an] = au
+        return out, expected
+
+    cached = death_events if death_events is not None else pd.DataFrame()
+    cached_out, expected = _mapping(cached)
+    if expected and expected.issubset({name.lower() for name in cached_out}):
+        return cached_out
     try:
-        de = _to_pandas_df(parser.parse_event("player_death", player=["user_id"]))
+        fresh = _to_pandas_df(parser.parse_event("player_death", player=["user_id"]))
     except BaseException as e:
         if isinstance(e, _DEMOPARSER_RE_RAISE):
             raise
-        return {}
-    if de.empty:
-        return {}
-    if match_start_tick > 0 and "tick" in de.columns:
-        de = de.loc[
-            pd.to_numeric(de["tick"], errors="coerce").fillna(0).astype(int) >= match_start_tick
-        ].copy()
-    out: dict[str, int] = {}
-    for _, row in de.iterrows():
-        vn = _cell_str(row.get("user_name"))
-        vu = _user_id_cell(row.get("user_user_id"))
-        if vn and vu is not None:
-            out[vn] = vu
-        an = _cell_str(row.get("attacker_name"))
-        au = _user_id_cell(row.get("attacker_user_id"))
-        if an and au is not None:
-            out[an] = au
-    return out
+        return cached_out
+    fresh_out, _ = _mapping(fresh)
+    return {**cached_out, **fresh_out}
 
 
 def _lookup_user_id_for_name(name_to_uid: dict[str, int], player_name: str) -> Optional[int]:
@@ -216,31 +269,51 @@ def _lookup_user_id_for_name(name_to_uid: dict[str, int], player_name: str) -> O
     return None
 
 
-def build_player_name_to_steam_id(parser: DemoParser, match_start_tick: int) -> dict[str, int]:
+def build_player_name_to_steam_id(
+    parser: DemoParser,
+    match_start_tick: int,
+    *,
+    death_events: Optional[pd.DataFrame] = None,
+) -> dict[str, int]:
     """player_death 中 user_steamid / attacker_steamid 汇总为「昵称 -> Steam64」。"""
+    def _mapping(frame: pd.DataFrame) -> tuple[dict[str, int], set[str]]:
+        if frame.empty:
+            return {}, set()
+        work = frame
+        if match_start_tick > 0 and "tick" in work.columns:
+            work = work.loc[
+                pd.to_numeric(work["tick"], errors="coerce").fillna(0).astype(int)
+                >= match_start_tick
+            ]
+        out: dict[str, int] = {}
+        expected: set[str] = set()
+        for _, row in work.iterrows():
+            vn = _cell_str(row.get("user_name"))
+            vs = _steam_id_cell(row.get("user_steamid"))
+            if vn:
+                expected.add(vn.lower())
+                if vs is not None:
+                    out[vn] = vs
+            an = _cell_str(row.get("attacker_name"))
+            ast = _steam_id_cell(row.get("attacker_steamid"))
+            if an:
+                expected.add(an.lower())
+                if ast is not None:
+                    out[an] = ast
+        return out, expected
+
+    cached = death_events if death_events is not None else pd.DataFrame()
+    cached_out, expected = _mapping(cached)
+    if expected and expected.issubset({name.lower() for name in cached_out}):
+        return cached_out
     try:
-        de = _to_pandas_df(parser.parse_event("player_death"))
+        fresh = _to_pandas_df(parser.parse_event("player_death"))
     except BaseException as e:
         if isinstance(e, _DEMOPARSER_RE_RAISE):
             raise
-        return {}
-    if de.empty:
-        return {}
-    if match_start_tick > 0 and "tick" in de.columns:
-        de = de.loc[
-            pd.to_numeric(de["tick"], errors="coerce").fillna(0).astype(int) >= match_start_tick
-        ].copy()
-    out: dict[str, int] = {}
-    for _, row in de.iterrows():
-        vn = _cell_str(row.get("user_name"))
-        vs = _steam_id_cell(row.get("user_steamid"))
-        if vn and vs is not None:
-            out[vn] = vs
-        an = _cell_str(row.get("attacker_name"))
-        ast = _steam_id_cell(row.get("attacker_steamid"))
-        if an and ast is not None:
-            out[an] = ast
-    return out
+        return cached_out
+    fresh_out, _ = _mapping(fresh)
+    return {**cached_out, **fresh_out}
 
 
 def _lookup_steam_id_for_name(name_to_sid: dict[str, int], player_name: str) -> Optional[int]:
@@ -261,14 +334,52 @@ def _build_all_players_roster(
     match_start_tick: int,
     spec_slots: dict[str, int],
     name_to_sid: dict[str, int],
+    *,
+    name_to_team_pi: Optional[dict[str, int]] = None,
+    player_ticks_df: Optional[pd.DataFrame] = None,
+    expected_names: Optional[list[str] | tuple[str, ...] | set[str]] = None,
 ) -> list[dict]:
     """全员名单：[{name, steamid64, spec_slot, team_num}, ...]。"""
-    try:
-        df = _to_pandas_df(parser.parse_ticks(["name", "team_num"], ticks=[max(1, match_start_tick)]))
-    except BaseException as e:
-        if isinstance(e, _DEMOPARSER_RE_RAISE):
-            raise
-        return []
+    desired_tick = max(1, match_start_tick)
+    cached_df = _player_tick_snapshot_at(player_ticks_df, desired_tick)
+    expected_name_keys = {
+        str(name).strip().lower()
+        for name in (
+            *name_to_sid.keys(),
+            *spec_slots.keys(),
+            *(name_to_team_pi or {}).keys(),
+            *(expected_names or ()),
+        )
+        if str(name).strip()
+    }
+    cached_usable_names = (
+        {
+            name.strip().lower()
+            for _, row in cached_df.iterrows()
+            if (name := _cell_str(row.get("name")))
+            and _cell_team(row.get("team_num")) in (2, 3)
+        }
+        if not cached_df.empty
+        else set()
+    )
+    cache_complete = bool(cached_usable_names) and (
+        not expected_name_keys or expected_name_keys.issubset(cached_usable_names)
+    )
+    df = cached_df
+    if not cache_complete:
+        try:
+            fresh_df = coalesce_player_team_num(_to_pandas_df(parser.parse_ticks(
+                ["name", "steamid", *PLAYER_TEAM_PARSE_FIELDS],
+                ticks=[desired_tick],
+            )))
+        except BaseException as e:
+            if isinstance(e, _DEMOPARSER_RE_RAISE):
+                raise
+            fresh_df = pd.DataFrame()
+        if not fresh_df.empty:
+            # Prefer the dedicated exact-tick read while retaining any names
+            # that were present only in the shared cache.
+            df = pd.concat([fresh_df, cached_df], ignore_index=True)
     if df.empty:
         return []
     players: list[dict] = []
@@ -285,7 +396,11 @@ def _build_all_players_roster(
         if team_num not in (2, 3):
             continue
         seen.add(name)
-        sid_int = name_to_sid.get(name) or name_to_sid.get(name.lower())
+        sid_int = (
+            name_to_sid.get(name)
+            or name_to_sid.get(name.lower())
+            or _steam_id_cell(row.get("steamid"))
+        )
         players.append({
             "name": name,
             "steamid64": str(sid_int) if sid_int is not None else "",
@@ -296,19 +411,32 @@ def _build_all_players_roster(
     # 逐 tick team_num 在部分国服 demo 上几乎全为空，会导致名单残缺/单边。
     # 此时用 parse_player_info 的可靠队伍补全全员。
     distinct = {p["team_num"] for p in players}
-    if len(players) < 6 or len(distinct) < 2:
-        name_to_team_pi = build_name_to_team_from_player_info(parser)
-        if name_to_team_pi:
-            df_names = [str(r.get("name", "")).strip() for _, r in df.iterrows()]
-            existing = {p["name"] for p in players}
-            for name in df_names:
-                if not name or name in existing:
+    output_name_keys = {str(player["name"]).strip().lower() for player in players}
+    missing_expected = expected_name_keys - output_name_keys
+    if len(players) < 6 or len(distinct) < 2 or missing_expected:
+        name_to_team_pi_resolved = (
+            name_to_team_pi
+            if name_to_team_pi is not None
+            else build_name_to_team_from_player_info(parser)
+        )
+        if name_to_team_pi_resolved:
+            candidate_names = [
+                str(row.get("name", "")).strip()
+                for _, row in df.iterrows()
+            ]
+            candidate_names.extend(str(name).strip() for name in expected_names or ())
+            candidate_names.extend(str(name).strip() for name in name_to_sid)
+            candidate_names.extend(str(name).strip() for name in spec_slots)
+            existing = {str(player["name"]).strip().lower() for player in players}
+            for name in candidate_names:
+                name_key = name.lower()
+                if not name or name_key in existing:
                     continue
-                tm = name_to_team_pi.get(name.lower())
+                tm = name_to_team_pi_resolved.get(name_key)
                 if tm not in (2, 3):
                     continue
-                existing.add(name)
-                sid_int = name_to_sid.get(name) or name_to_sid.get(name.lower())
+                existing.add(name_key)
+                sid_int = _lookup_steam_id_for_name(name_to_sid, name)
                 players.append({
                     "name": name,
                     "steamid64": str(sid_int) if sid_int is not None else "",
@@ -372,16 +500,42 @@ def build_player_name_to_spec_player_slot_dict(
     parser: DemoParser,
     tick_i: int,
     dem_path: str | Path | None = None,
+    *,
+    player_ticks_df: Optional[pd.DataFrame] = None,
+    expected_names: Optional[list[str] | tuple[str, ...] | set[str]] = None,
 ) -> dict[str, int]:
     """在某一 tick 快照上建立「玩家昵称(小写) -> spec_player 应传入的整数」。"""
     observed: list[int] = []
     t = max(1, int(tick_i)) if int(tick_i) <= 0 else int(tick_i)
-    try:
-        df = _to_pandas_df(parser.parse_ticks(["user_id", "name"], ticks=[t]))
-    except BaseException as e:
-        if isinstance(e, _DEMOPARSER_RE_RAISE):
-            raise
-        return {}
+    cached_df = _player_tick_snapshot_at(player_ticks_df, t)
+    valid_cached_names: set[str] = set()
+    if not cached_df.empty and "user_id" in cached_df.columns and "name" in cached_df.columns:
+        valid_cached_names = {
+            str(name).strip().lower()
+            for _, row in cached_df.iterrows()
+            if (name := _cell_str(row.get("name")))
+            and _user_id_cell(row.get("user_id")) is not None
+        }
+    expected = {
+        str(name).strip().lower()
+        for name in expected_names or ()
+        if str(name).strip()
+    }
+    cache_complete = bool(valid_cached_names) and (
+        not expected or expected.issubset(valid_cached_names)
+    )
+    df = cached_df
+    if not cache_complete:
+        try:
+            fresh_df = _to_pandas_df(parser.parse_ticks(["user_id", "name"], ticks=[t]))
+        except BaseException as e:
+            if isinstance(e, _DEMOPARSER_RE_RAISE):
+                raise
+            fresh_df = pd.DataFrame()
+        if not fresh_df.empty:
+            # Fresh rows are appended so duplicate names overwrite cached IDs
+            # when the mapping dict is built below.
+            df = pd.concat([cached_df, fresh_df], ignore_index=True)
     if df.empty or "user_id" not in df.columns or "name" not in df.columns:
         return {}
     out: dict[str, int] = {}
@@ -412,9 +566,12 @@ def _compute_spec_slot_legacy_team_steam_sort(
     """旧版启发式：(team_num, steamid) 排序；仅作无 user_id 时的回退。"""
     try:
         parser = DemoParser(str(dem_path))
-        df = _to_pandas_df(
-            parser.parse_ticks(["name", "steamid", "team_num"], ticks=[tick_i]),
-        )
+        df = coalesce_player_team_num(_to_pandas_df(
+            parser.parse_ticks(
+                ["name", "steamid", *PLAYER_TEAM_PARSE_FIELDS],
+                ticks=[tick_i],
+            ),
+        ))
     except BaseException as e:
         if isinstance(e, _DEMOPARSER_RE_RAISE):
             raise
@@ -472,9 +629,12 @@ def compute_spec_player_slot_one_based(
         except BaseException as e:
             if isinstance(e, _DEMOPARSER_RE_RAISE):
                 raise
-        df = _to_pandas_df(
-            parser.parse_ticks(["user_id", "name", "steamid", "team_num"], ticks=[tick_i]),
-        )
+        df = coalesce_player_team_num(_to_pandas_df(
+            parser.parse_ticks(
+                ["user_id", "name", "steamid", *PLAYER_TEAM_PARSE_FIELDS],
+                ticks=[tick_i],
+            ),
+        ))
     except BaseException as e:
         if isinstance(e, _DEMOPARSER_RE_RAISE):
             raise
@@ -618,9 +778,9 @@ def get_player_list(dem_path: str | Path) -> list[dict]:
 
     if match_start_tick > 0 and stats:
         try:
-            fix_df = _to_pandas_df(
-                parser.parse_ticks(["team_num", "name"], ticks=[match_start_tick]),
-            )
+            fix_df = coalesce_player_team_num(_to_pandas_df(
+                parser.parse_ticks(PLAYER_TEAM_PARSE_FIELDS + ["name"], ticks=[match_start_tick]),
+            ))
         except BaseException as e:
             if isinstance(e, _DEMOPARSER_RE_RAISE):
                 raise

--- a/backend/app/parser/round_economy.py
+++ b/backend/app/parser/round_economy.py
@@ -14,8 +14,29 @@ from .parse_utils import (
     _cell_team,
     _cell_str,
     _winner_side_engine_num,
+    PLAYER_TEAM_PARSE_FIELDS,
+    coalesce_player_team_num,
 )
 from .tag_constants import TICK_RATE, _EXTRA_EVENT_FIELDS
+
+
+def _round_end_frame_usable(
+    frame: Optional[pd.DataFrame],
+    match_start_tick: int = 0,
+) -> bool:
+    """Whether a cached round_end frame can safely replace a dedicated parse."""
+    if frame is None or frame.empty or "winner" not in frame.columns:
+        return False
+    work = frame
+    if match_start_tick > 0 and "tick" not in work.columns:
+        return False
+    if match_start_tick > 0:
+        work = work.loc[
+            pd.to_numeric(work["tick"], errors="coerce").fillna(0).astype(int)
+            >= match_start_tick
+        ]
+    winners = [_round_end_winner_team_num(value) for value in work["winner"].tolist()]
+    return bool(winners) and all(winner in (2, 3) for winner in winners)
 
 
 def build_round_economy_shared(
@@ -102,17 +123,34 @@ def build_round_economy_shared(
     if not ticks:
         return {}, round_freeze_end_ticks, round_freeze_start_ticks, tick_to_round, pd.DataFrame()
 
+    economy_fields = PLAYER_TEAM_PARSE_FIELDS + [
+        "current_equip_value", "is_alive", "name", "steamid", "user_id",
+    ]
     try:
-        raw = parser.parse_ticks(
-            ["team_num", "current_equip_value", "is_alive", "name"],
-            ticks=ticks,
-        )
-        economy_ticks_df = _to_pandas_df(raw)
+        raw = parser.parse_ticks(economy_fields, ticks=ticks)
+        economy_ticks_df = coalesce_player_team_num(_to_pandas_df(raw))
     except Exception:
         return {}, round_freeze_end_ticks, round_freeze_start_ticks, tick_to_round, pd.DataFrame()
 
     if economy_ticks_df.empty or "tick" not in economy_ticks_df.columns:
         return {}, round_freeze_end_ticks, round_freeze_start_ticks, tick_to_round, pd.DataFrame()
+
+    observed_ticks = set(
+        pd.to_numeric(economy_ticks_df["tick"], errors="coerce").dropna().astype(int)
+    )
+    missing_ticks = sorted(set(ticks) - observed_ticks)
+    if missing_ticks:
+        try:
+            retry_df = coalesce_player_team_num(
+                _to_pandas_df(parser.parse_ticks(economy_fields, ticks=missing_ticks))
+            )
+        except Exception:
+            retry_df = pd.DataFrame()
+        if not retry_df.empty:
+            economy_ticks_df = pd.concat(
+                [economy_ticks_df, retry_df],
+                ignore_index=True,
+            )
 
     economy_map: dict[int, dict[int, int]] = {}
     for tick, grp in economy_ticks_df.groupby("tick", sort=False):
@@ -203,9 +241,15 @@ def build_round_economy(
 def build_round_scores(
     parser: DemoParser,
     match_start_tick: int = 0,
+    *,
+    re_df: Optional[pd.DataFrame] = None,
 ) -> dict[int, dict[int, int]]:
     """解析 round_end，返回每回合**开始前**的双方比分 {round: {2: T胜场, 3: CT胜场}}。"""
-    re = _safe_parse_event(parser, "round_end", other=list(_EXTRA_EVENT_FIELDS))
+    re = (
+        re_df
+        if _round_end_frame_usable(re_df, match_start_tick)
+        else _safe_parse_event(parser, "round_end", other=list(_EXTRA_EVENT_FIELDS))
+    )
     if match_start_tick > 0 and not re.empty and "tick" in re.columns:
         re = re.loc[pd.to_numeric(re["tick"], errors="coerce").fillna(0).astype(int) >= match_start_tick]
     if re.empty:
@@ -252,7 +296,7 @@ def build_round_scores_team_based(
 
     re_df: 已过滤 warmup 的 round_end DataFrame，有则直接用，省一次 parse_event。
     """
-    if re_df is not None:
+    if _round_end_frame_usable(re_df, match_start_tick):
         re = re_df
     else:
         re = _safe_parse_event(parser, "round_end", other=list(_EXTRA_EVENT_FIELDS))
@@ -312,6 +356,8 @@ def build_group_side_by_round(
     parser: DemoParser,
     round_freeze_end_ticks: dict[int, int],
     steam_to_final_team: dict[str, int],
+    *,
+    player_ticks_df: Optional[pd.DataFrame] = None,
 ) -> dict[int, dict[int, int]]:
     """每回合两支「队伍身份」各自所处阵营。
 
@@ -325,10 +371,35 @@ def build_group_side_by_round(
     if not round_freeze_end_ticks or not steam_to_final_team:
         return {}
     ticks = sorted(set(round_freeze_end_ticks.values()))
-    try:
-        df = _to_pandas_df(parser.parse_ticks(["team_num", "steamid"], ticks=ticks))
-    except Exception:
-        return {}
+    df = pd.DataFrame()
+    if player_ticks_df is not None and not player_ticks_df.empty:
+        df = coalesce_player_team_num(player_ticks_df)
+        if "tick" in df.columns:
+            df = df.loc[pd.to_numeric(df["tick"], errors="coerce").isin(ticks)]
+
+    def _ticks_with_usable_observation(frame: pd.DataFrame) -> set[int]:
+        usable: set[int] = set()
+        if frame.empty or "tick" not in frame.columns:
+            return usable
+        for tick, grp in frame.groupby("tick", sort=False):
+            for _, row in grp.iterrows():
+                final_team = steam_to_final_team.get(_norm_steam_id(row.get("steamid")))
+                if final_team in (2, 3) and _cell_team(row.get("team_num")) in (2, 3):
+                    usable.add(int(tick))
+                    break
+        return usable
+
+    missing_ticks = sorted(set(ticks) - _ticks_with_usable_observation(df))
+    if missing_ticks:
+        try:
+            fresh_df = coalesce_player_team_num(_to_pandas_df(parser.parse_ticks(
+                PLAYER_TEAM_PARSE_FIELDS + ["steamid"],
+                ticks=missing_ticks,
+            )))
+        except Exception:
+            fresh_df = pd.DataFrame()
+        if not fresh_df.empty:
+            df = pd.concat([df, fresh_df], ignore_index=True)
     if df.empty or "tick" not in df.columns:
         return {}
 
@@ -497,8 +568,12 @@ def _scoreline_by_starting_roster(
 
     try:
         roster_df = _to_pandas_df(
-            parser.parse_ticks(["steamid", "team_num", "name"], ticks=[match_start_tick]),
+            parser.parse_ticks(
+                ["steamid", *PLAYER_TEAM_PARSE_FIELDS, "name"],
+                ticks=[match_start_tick],
+            ),
         )
+        roster_df = coalesce_player_team_num(roster_df)
     except BaseException as e:
         if isinstance(e, (KeyboardInterrupt, SystemExit, GeneratorExit)):
             raise
@@ -520,8 +595,12 @@ def _scoreline_by_starting_roster(
 
     try:
         big = _to_pandas_df(
-            parser.parse_ticks(["steamid", "team_num", "name"], ticks=ticks_needed),
+            parser.parse_ticks(
+                ["steamid", *PLAYER_TEAM_PARSE_FIELDS, "name"],
+                ticks=ticks_needed,
+            ),
         )
+        big = coalesce_player_team_num(big)
     except BaseException as e:
         if isinstance(e, (KeyboardInterrupt, SystemExit, GeneratorExit)):
             raise

--- a/backend/app/parser/spatial_analysis.py
+++ b/backend/app/parser/spatial_analysis.py
@@ -7,7 +7,15 @@ from typing import Optional
 import pandas as pd
 from demoparser2 import DemoParser
 
-from .parse_utils import _to_pandas_df, _int, _bool, _DEMOPARSER_RE_RAISE
+from .parse_utils import (
+    _to_pandas_df,
+    _int,
+    _bool,
+    _DEMOPARSER_RE_RAISE,
+    PLAYER_CONTROLLER_TEAM_PROP,
+    PLAYER_TEAM_PARSE_FIELDS,
+    coalesce_player_team_num,
+)
 from .tag_constants import (
     TICK_RATE,
     PISTOL_WEAPONS,
@@ -93,18 +101,22 @@ def _victim_facing_attacker(
     victim: str,
     *,
     max_angle_deg: float = 45.0,
-) -> bool:
-    """死亡瞬间受害者的 yaw 是否指向攻击者（±max_angle_deg 内）。"""
+) -> Optional[bool]:
+    """死亡瞬间受害者是否面向攻击者；空间信息不足时返回 ``None``。"""
     v = _spatial_player_row(tick_dict, victim)
     a = _spatial_player_row(tick_dict, attacker)
     if v is None or a is None:
-        return False
+        return None
     try:
         vx, vy = float(v["X"]), float(v["Y"])
         ax, ay = float(a["X"]), float(a["Y"])
         vyaw   = float(v["yaw"])
     except (TypeError, ValueError, KeyError):
-        return False
+        return None
+    if not all(math.isfinite(value) for value in (vx, vy, ax, ay, vyaw)):
+        return None
+    if math.hypot(ax - vx, ay - vy) < 1.0:
+        return None
     target_yaw = math.degrees(math.atan2(ay - vy, ax - vx))
     diff = ((target_yaw - vyaw + 180.0) % 360.0) - 180.0
     return abs(diff) <= max_angle_deg
@@ -145,6 +157,11 @@ def _alive_mates_and_enemies(
     alive_by_team: "Optional[dict[int, frozenset]]" = None,
 ) -> "Optional[tuple[int, int]]":
     """返回 (同队存活队友数不含自己, 敌方存活人数)；无法统计时返回 None。"""
+    # A controller-only identity can recover a player's team, but it cannot
+    # prove that the associated pawn is alive or dead.  Treat the whole count
+    # as unknown instead of under-counting such players into a false clutch.
+    if any(row.get("_pawn_state_known") is False for row in tick_dict.values()):
+        return None
     row_self = _spatial_player_row(tick_dict, target_player)
     if row_self is None:
         return None
@@ -250,20 +267,40 @@ def parse_spatial_snapshots(
                 "X", "Y", "Z",
                 "vel_x", "vel_y", "vel_z",
                 "yaw", "pitch",
-                "name", "is_alive", "team_num", "health", "armor",
+                "name", "is_alive", *PLAYER_TEAM_PARSE_FIELDS, "health", "armor",
             ],
             ticks=unique_ticks,
         )
     except Exception:
         try:
             result = parser.parse_ticks(
-                ["X", "Y", "Z", "vel_z", "yaw", "pitch", "name", "is_alive", "team_num", "health", "armor"],
+                [
+                    "X", "Y", "Z", "vel_z", "yaw", "pitch", "name", "is_alive",
+                    *PLAYER_TEAM_PARSE_FIELDS, "health", "armor",
+                ],
                 ticks=unique_ticks,
             )
         except Exception:
             return {}, {}
     try:
-        df = _to_pandas_df(result)
+        raw_df = _to_pandas_df(result)
+        if raw_df.empty:
+            return {}, {}
+        if "team_num" in raw_df.columns:
+            primary_team = pd.to_numeric(raw_df["team_num"], errors="coerce")
+        else:
+            primary_team = pd.Series(float("nan"), index=raw_df.index)
+        if PLAYER_CONTROLLER_TEAM_PROP in raw_df.columns:
+            controller_team = pd.to_numeric(
+                raw_df[PLAYER_CONTROLLER_TEAM_PROP], errors="coerce",
+            )
+        else:
+            controller_team = pd.Series(float("nan"), index=raw_df.index)
+        controller_only_team = (
+            ~primary_team.isin((2, 3)) & controller_team.isin((2, 3))
+        )
+        df = coalesce_player_team_num(raw_df)
+        df["_team_from_controller"] = controller_only_team
         if df.empty:
             return {}, {}
         cache: dict[int, dict[str, dict]] = {}
@@ -275,8 +312,18 @@ def parse_spatial_snapshots(
                 name = str(row.get("name") or "").strip()
                 if name:
                     row_d = row.to_dict()
+                    try:
+                        has_pawn_position = all(
+                            math.isfinite(float(row_d[key])) for key in ("X", "Y")
+                        )
+                    except (TypeError, ValueError, KeyError):
+                        has_pawn_position = False
+                    row_d["_pawn_state_known"] = not (
+                        bool(row_d.get("_team_from_controller"))
+                        and not has_pawn_position
+                    )
                     tick_dict[name] = row_d
-                    if row_d.get("is_alive"):
+                    if row_d["_pawn_state_known"] and row_d.get("is_alive"):
                         try:
                             tm = int(float(row_d["team_num"]))
                             by_team.setdefault(tm, set()).add(name)
@@ -738,7 +785,8 @@ def enrich_kill_action_tags_spatial(
 
             # ── 偷背身（枪版）：受害者背对攻击者 ──
             if weapon not in KNIFE_WEAPONS and vic_name and snap:
-                if not _victim_facing_attacker(snap, target_player, vic_name):
+                facing = _victim_facing_attacker(snap, target_player, vic_name)
+                if facing is False:
                     extra.append("🔙 偷背身")
 
             # ── 速度：用 X/Y 位置差估算（demoparser2 0.41.2 不暴露 vel_x/vel_y，会静默丢列）──

--- a/backend/tests/test_analyzer_shared_ir.py
+++ b/backend/tests/test_analyzer_shared_ir.py
@@ -1,0 +1,381 @@
+import inspect
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from app.parser import analyzer as analyzer_module
+from app.parser.analyzer import DemoAnalyzer
+from app.parser.parse_utils import _max_demo_tick
+from app.parser.player_roster import (
+    build_player_name_to_steam_id,
+    build_player_name_to_user_id,
+)
+from app.parser.round_economy import build_round_scores
+
+
+class _ParserMustNotRun:
+    def __getattr__(self, name):
+        raise AssertionError(f"unexpected native parser call: {name}")
+
+
+def test_precomputed_frames_do_not_reparse_death_or_round_events():
+    parser = _ParserMustNotRun()
+    deaths = pd.DataFrame(
+        [
+            {
+                "tick": 120,
+                "user_name": "alpha",
+                "user_user_id": 2,
+                "user_steamid": "76561198000000001",
+                "attacker_name": "bravo",
+                "attacker_user_id": 7,
+                "attacker_steamid": "76561198000000002",
+            }
+        ]
+    )
+    round_ends = pd.DataFrame(
+        [
+            {"tick": 100, "total_rounds_played": 1, "winner": "T"},
+            {"tick": 200, "total_rounds_played": 2, "winner": "CT"},
+        ]
+    )
+
+    assert build_player_name_to_user_id(
+        parser, 0, death_events=deaths
+    ) == {"alpha": 2, "bravo": 7}
+    assert build_player_name_to_steam_id(
+        parser, 0, death_events=deaths
+    ) == {
+        "alpha": 76561198000000001,
+        "bravo": 76561198000000002,
+    }
+    assert _max_demo_tick(parser, round_ends, 0, death_df=deaths) == 200
+    assert build_round_scores(parser, 0, re_df=round_ends) == {
+        1: {2: 0, 3: 0},
+        2: {2: 1, 3: 0},
+        3: {2: 1, 3: 1},
+    }
+
+
+def test_empty_precomputed_frames_retry_legacy_event_paths():
+    class Parser:
+        def __init__(self):
+            self.calls = []
+
+        def parse_event(self, event_name, **_kwargs):
+            self.calls.append(event_name)
+            if event_name == "player_death":
+                return pd.DataFrame(
+                    [
+                        {
+                            "tick": 120,
+                            "user_name": "alpha",
+                            "user_user_id": 2,
+                            "user_steamid": "76561198000000001",
+                            "attacker_name": "bravo",
+                            "attacker_user_id": 7,
+                            "attacker_steamid": "76561198000000002",
+                        }
+                    ]
+                )
+            if event_name == "round_end":
+                return pd.DataFrame(
+                    [{"tick": 200, "total_rounds_played": 1, "winner": "T"}]
+                )
+            raise AssertionError(event_name)
+
+    parser = Parser()
+    empty = pd.DataFrame()
+
+    assert build_player_name_to_user_id(parser, 0, death_events=empty) == {
+        "alpha": 2,
+        "bravo": 7,
+    }
+    assert build_player_name_to_steam_id(parser, 0, death_events=empty) == {
+        "alpha": 76561198000000001,
+        "bravo": 76561198000000002,
+    }
+    assert _max_demo_tick(parser, empty, 0, death_df=empty) == 120
+    assert build_round_scores(parser, 0, re_df=empty) == {
+        1: {2: 0, 3: 0},
+        2: {2: 1, 3: 0},
+    }
+    assert parser.calls == [
+        "player_death",
+        "player_death",
+        "player_death",
+        "round_end",
+    ]
+
+
+def test_nonempty_but_unusable_precomputed_frames_retry_legacy_paths():
+    class Parser:
+        def __init__(self):
+            self.calls = []
+
+        def parse_event(self, event_name, **_kwargs):
+            self.calls.append(event_name)
+            if event_name == "player_death":
+                return pd.DataFrame(
+                    [
+                        {
+                            "tick": 120,
+                            "user_name": "alpha",
+                            "user_user_id": 2,
+                            "user_steamid": "76561198000000001",
+                            "attacker_name": "bravo",
+                            "attacker_user_id": 7,
+                            "attacker_steamid": "76561198000000002",
+                        }
+                    ]
+                )
+            if event_name == "round_end":
+                return pd.DataFrame(
+                    [{"tick": 200, "total_rounds_played": 1, "winner": "T"}]
+                )
+            raise AssertionError(event_name)
+
+    parser = Parser()
+    unusable_deaths = pd.DataFrame(
+        [{"tick": 120, "user_name": "alpha", "attacker_name": "bravo"}]
+    )
+    unusable_rounds = pd.DataFrame(
+        [{"tick": 200, "total_rounds_played": 1}]
+    )
+
+    assert build_player_name_to_user_id(
+        parser,
+        0,
+        death_events=unusable_deaths,
+    ) == {"alpha": 2, "bravo": 7}
+    assert build_player_name_to_steam_id(
+        parser,
+        0,
+        death_events=unusable_deaths,
+    ) == {
+        "alpha": 76561198000000001,
+        "bravo": 76561198000000002,
+    }
+    assert build_round_scores(parser, 0, re_df=unusable_rounds) == {
+        1: {2: 0, 3: 0},
+        2: {2: 1, 3: 0},
+    }
+    assert build_round_scores(
+        parser,
+        50,
+        re_df=pd.DataFrame([{"total_rounds_played": 1, "winner": "T"}]),
+    ) == {
+        1: {2: 0, 3: 0},
+        2: {2: 1, 3: 0},
+    }
+    assert parser.calls == [
+        "player_death",
+        "player_death",
+        "round_end",
+        "round_end",
+    ]
+
+
+def test_multi_player_analysis_builds_shared_facts_once(monkeypatch):
+    empty = pd.DataFrame()
+    shared_events = {
+        "events": empty,
+        "fire_df": empty,
+        "hurt_df": empty,
+        "equip_df": empty,
+        "pickup_df": empty,
+        "planted_df": empty,
+        "defused_df": empty,
+        "bomb_exploded_df": empty,
+        "begindefuse_df": empty,
+        "nade_batch": {},
+        "re_df_cached": empty,
+        "win_panel_match_tick": 0,
+        "blind_df": empty,
+        "economy_map_shared": {},
+        "round_freeze_end_ticks_shared": {},
+        "round_freeze_start_ticks_shared": {},
+        "tick_to_round_shared": {},
+        "economy_ticks_df": empty,
+        "freeze_end_df": empty,
+        "round_start_df": empty,
+        "match_start_df": empty,
+        "steam_to_final_team_shared": {},
+        "name_to_final_team_shared": {},
+        "group_side_by_round_shared": {},
+        "player_info_df": empty,
+    }
+
+    class _HeaderOnlyParser:
+        def __init__(self):
+            self.header_calls = 0
+
+        def parse_header(self):
+            self.header_calls += 1
+            return {"map_name": "de_test"}
+
+    parser = _HeaderOnlyParser()
+    analyzer = object.__new__(DemoAnalyzer)
+    analyzer.dem_path = Path("fixture.dem")
+    analyzer.parser = parser
+
+    facts = object()
+    fact_builds = []
+    finish_facts = []
+
+    monkeypatch.setattr(analyzer_module, "_get_match_start_tick", lambda _parser: 1)
+    monkeypatch.setattr(analyzer, "_parse_shared_events", lambda _tick: shared_events)
+
+    def fake_build_facts(**kwargs):
+        fact_builds.append(kwargs)
+        return facts
+
+    monkeypatch.setattr(analyzer, "_build_shared_demo_facts", fake_build_facts)
+    monkeypatch.setattr(
+        analyzer_module,
+        "parse_spatial_snapshots",
+        lambda _parser, _ticks: ({}, {}),
+    )
+
+    def fake_finish(**kwargs):
+        finish_facts.append(kwargs["shared_facts"])
+        return kwargs["target_player"]
+
+    monkeypatch.setattr(analyzer, "_finish_single_player_analysis", fake_finish)
+
+    players = [f"player-{index}" for index in range(10)]
+    result = analyzer.analyze_multi_players(players)
+
+    assert list(result) == players
+    assert len(fact_builds) == 1
+    assert fact_builds[0]["expected_players"] == players
+    assert finish_facts == [facts] * 10
+    assert parser.header_calls == 1
+
+
+def test_shared_facts_materialize_event_indexes_and_copy_rosters(monkeypatch):
+    analyzer = object.__new__(DemoAnalyzer)
+    analyzer.dem_path = Path("fixture.dem")
+    analyzer.parser = object()
+
+    events = pd.DataFrame(
+        [
+            {
+                "tick": 100,
+                "attacker_name": "alpha",
+                "user_name": "bravo",
+                "assister_name": "charlie",
+            },
+            {
+                "tick": 200,
+                "attacker_name": "delta",
+                "user_name": "alpha",
+                "assister_name": pd.NA,
+            },
+            {
+                "tick": 300,
+                "attacker_name": "echo",
+                "user_name": "foxtrot",
+                "assister_name": "alpha",
+            },
+        ]
+    )
+    round_ends = pd.DataFrame(
+        [
+            {"tick": 150, "total_rounds_played": 1},
+            {"tick": 250, "total_rounds_played": 2},
+        ]
+    )
+    shared_events = {
+        "events": events,
+        "re_df_cached": round_ends,
+        "blind_df": pd.DataFrame(
+            [
+                {"tick": 130, "user_name": "bravo", "blind_duration": 1.5},
+                {"tick": 110, "user_name": "bravo", "blind_duration": 2.0},
+            ]
+        ),
+        "nade_batch": {
+            "hegrenade_detonate": pd.DataFrame(
+                [{"tick": 210, "x": 20.0, "y": 30.0}]
+            ),
+            "smokegrenade_detonate": pd.DataFrame(
+                [{"tick": 120, "X": 10.0, "Y": 15.0}]
+            ),
+        },
+        "bomb_exploded_df": pd.DataFrame(
+            [
+                {"tick": 240, "total_rounds_played": 1},
+                {"tick": 245, "total_rounds_played": 1},
+            ]
+        ),
+        "name_to_final_team_shared": {"alpha": 2, "bravo": 3},
+    }
+
+    monkeypatch.setattr(
+        analyzer,
+        "_build_match_summary",
+        lambda *_args, **_kwargs: (13, 9, "", 42, "A", "B"),
+    )
+    monkeypatch.setattr(analyzer_module, "_max_demo_tick", lambda *_args, **_kwargs: 999)
+    monkeypatch.setattr(
+        analyzer_module,
+        "build_player_name_to_user_id",
+        lambda *_args, **_kwargs: {"alpha": 1, "bravo": 2},
+    )
+    monkeypatch.setattr(
+        analyzer_module,
+        "build_player_name_to_spec_player_slot_dict",
+        lambda *_args, **_kwargs: {"alpha": 1, "bravo": 2},
+    )
+    monkeypatch.setattr(
+        analyzer_module,
+        "build_player_name_to_steam_id",
+        lambda *_args, **_kwargs: {"alpha": 76561198000000001},
+    )
+    monkeypatch.setattr(
+        analyzer_module,
+        "_build_all_players_roster",
+        lambda *_args, **_kwargs: [
+            {"name": "alpha", "steamid64": "76561198000000001", "team_num": 2}
+        ],
+    )
+    monkeypatch.setattr(
+        analyzer_module,
+        "build_round_scores",
+        lambda *_args, **_kwargs: {1: {2: 0, 3: 0}},
+    )
+
+    facts = analyzer._build_shared_demo_facts(
+        match_start_tick=1,
+        header={"server_name": "FACEIT"},
+        shared_events=shared_events,
+    )
+
+    assert facts.match_summary == (13, 9, "", 42, "A", "B")
+    assert facts.demo_max_tick == 999
+    assert facts.server_name == "FACEIT"
+    assert facts.victim_blind_index == {"bravo": [(110, 2.0), (130, 1.5)]}
+    assert facts.grenade_detonate_points == [
+        (120, 10.0, 15.0),
+        (210, 20.0, 30.0),
+    ]
+    assert facts.bomb_explode_tick_map == {2: 240}
+    assert facts.round_end_tick_map == {1: 150, 2: 250}
+    assert facts.timeline_event_positions_by_player["alpha"] == (0, 1, 2)
+    assert facts.timeline_event_positions_by_player["bravo"] == (0,)
+    assert facts.timeline_event_positions_by_player["charlie"] == (0,)
+
+    first_roster = facts.roster_snapshot()
+    second_roster = facts.roster_snapshot()
+    first_roster[0]["name"] = "mutated"
+    assert second_roster[0]["name"] == "alpha"
+    assert facts.all_players_roster[0]["name"] == "alpha"
+
+
+def test_per_player_finish_path_has_no_native_parser_access():
+    source = inspect.getsource(DemoAnalyzer._finish_single_player_analysis)
+    assert "self.parser" not in source

--- a/backend/tests/test_parse_demo_multi.py
+++ b/backend/tests/test_parse_demo_multi.py
@@ -1,0 +1,70 @@
+import asyncio
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from app import demo_parse_isolation, main
+from app.env_utils import AppConfig, LLMConfig
+
+
+def _run_parse_multi(*, players: list[str], filename: str = "match.dem", locale: str = "zh") -> dict:
+    request = main.ParseMultiRequest(target_players=players, locale=locale)
+    return asyncio.run(main.parse_demo_multi(request, filename))
+
+
+def test_parse_demo_multi_uses_one_shared_worker(monkeypatch, tmp_path):
+    demo_path = tmp_path / "match.dem"
+    demo_path.write_bytes(b"demo")
+    monkeypatch.setattr(main, "UPLOAD_DIR", tmp_path)
+    monkeypatch.setattr(main, "load_config", AppConfig)
+
+    calls: list[tuple[str, list[str], list[int] | None]] = []
+    expected = {
+        "alpha": {"clips": [{"id": "a"}], "match_meta": {"map_name": "de_nuke"}},
+        "bravo": {"clips": [{"id": "b"}], "match_meta": {"map_name": "de_nuke"}},
+    }
+
+    def fake_analyze_multi(dem_path, target_players, freeze_to_death_rounds):
+        calls.append((dem_path, target_players, freeze_to_death_rounds))
+        return expected
+
+    monkeypatch.setattr(demo_parse_isolation, "analyze_multi_isolated", fake_analyze_multi)
+
+    response = _run_parse_multi(players=["alpha", "bravo"])
+
+    assert response == {"players": expected}
+    assert calls == [(str(demo_path), ["alpha", "bravo"], None)]
+
+
+def test_parse_demo_multi_keeps_per_player_ai_review(monkeypatch, tmp_path):
+    from app import ai_reviewer
+
+    demo_path = tmp_path / "match.dem"
+    demo_path.write_bytes(b"demo")
+    monkeypatch.setattr(main, "UPLOAD_DIR", tmp_path)
+    monkeypatch.setattr(
+        main,
+        "load_config",
+        lambda: AppConfig(ai_mode=True, llm=LLMConfig(api_key="test-key")),
+    )
+
+    parsed = {
+        "alpha": {"clips": [{"id": "a"}], "match_meta": {"target_player": "alpha"}},
+        "bravo": {"clips": [{"id": "b"}], "match_meta": {"target_player": "bravo"}},
+    }
+    monkeypatch.setattr(demo_parse_isolation, "analyze_multi_isolated", lambda *_args: parsed)
+
+    reviewed_players: list[tuple[str, str]] = []
+
+    async def fake_enrich(clips, match_meta, _llm, *, locale):
+        reviewed_players.append((match_meta["target_player"], locale))
+        return [dict(clip, reviewed=True) for clip in clips]
+
+    monkeypatch.setattr(ai_reviewer, "enrich_clips_dicts_with_reviewer", fake_enrich)
+
+    response = _run_parse_multi(players=["alpha", "bravo"], locale="en")
+
+    assert sorted(reviewed_players) == [("alpha", "en"), ("bravo", "en")]
+    assert response["players"]["alpha"]["clips"] == [{"id": "a", "reviewed": True}]
+    assert response["players"]["bravo"]["clips"] == [{"id": "b", "reviewed": True}]

--- a/backend/tests/test_player_team_fallback.py
+++ b/backend/tests/test_player_team_fallback.py
@@ -1,0 +1,520 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import Mock
+
+import pandas as pd
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from app.parser.parse_utils import (
+    PLAYER_CONTROLLER_TEAM_PROP,
+    PLAYER_TEAM_PARSE_FIELDS,
+    coalesce_player_team_num,
+)
+from app.parser.player_roster import (
+    _build_all_players_roster,
+    _build_tick_team_lookup,
+    build_player_name_to_spec_player_slot_dict,
+)
+from app.parser.round_economy import (
+    build_group_side_by_round,
+    build_round_economy_shared,
+    extract_target_team_map,
+)
+from app.parser.spatial_analysis import parse_spatial_snapshots
+from app.parser.spatial_analysis import (
+    _alive_mates_and_enemies,
+    _victim_facing_attacker,
+    enrich_kill_action_tags_spatial,
+)
+
+
+def test_coalesce_player_team_num_prefers_valid_alias_and_fills_from_controller():
+    source = pd.DataFrame(
+        {
+            "name": ["missing", "valid", "invalid", "unknown"],
+            "team_num": [float("nan"), 2, 0, float("nan")],
+            PLAYER_CONTROLLER_TEAM_PROP: [3, 3, 2, 0],
+        }
+    )
+
+    result = coalesce_player_team_num(source)
+
+    assert result["team_num"].tolist()[:3] == [3.0, 2.0, 2.0]
+    assert pd.isna(result.iloc[3]["team_num"])
+    assert pd.isna(source.iloc[0]["team_num"]), "normalization must not mutate shared input"
+
+
+def test_round_economy_recovers_all_players_without_an_extra_parse():
+    parser = Mock()
+    parser.parse_ticks.return_value = pd.DataFrame(
+        [
+            {
+                "tick": 100,
+                "name": "alpha",
+                "team_num": float("nan"),
+                PLAYER_CONTROLLER_TEAM_PROP: 2,
+                "current_equip_value": 1000,
+                "is_alive": True,
+            },
+            {
+                "tick": 100,
+                "name": "bravo",
+                "team_num": 3,
+                PLAYER_CONTROLLER_TEAM_PROP: 3,
+                "current_equip_value": 2000,
+                "is_alive": True,
+            },
+            {
+                "tick": 200,
+                "name": "alpha",
+                "team_num": float("nan"),
+                PLAYER_CONTROLLER_TEAM_PROP: 3,
+                "current_equip_value": 3000,
+                "is_alive": True,
+            },
+            {
+                "tick": 200,
+                "name": "bravo",
+                "team_num": 2,
+                PLAYER_CONTROLLER_TEAM_PROP: 2,
+                "current_equip_value": 4000,
+                "is_alive": True,
+            },
+        ]
+    )
+    freeze_end = pd.DataFrame(
+        {"tick": [100, 200], "total_rounds_played": [0, 1]}
+    )
+    round_start = pd.DataFrame({"tick": [90, 150]})
+
+    economy, _, _, tick_to_round, ticks_df = build_round_economy_shared(
+        parser,
+        freeze_end_df=freeze_end,
+        round_start_df=round_start,
+    )
+
+    parser.parse_ticks.assert_called_once_with(
+        PLAYER_TEAM_PARSE_FIELDS + [
+            "current_equip_value", "is_alive", "name", "steamid", "user_id",
+        ],
+        ticks=[100, 200],
+    )
+    assert economy == {1: {2: 1000, 3: 2000}, 2: {2: 4000, 3: 3000}}
+    assert extract_target_team_map(ticks_df, tick_to_round, "alpha") == {1: 2, 2: 3}
+
+
+def test_round_economy_retries_missing_requested_ticks():
+    parser = Mock()
+    parser.parse_ticks.side_effect = [
+        pd.DataFrame(
+            [
+                {
+                    "tick": 100,
+                    "name": "alpha",
+                    "team_num": 2,
+                    "current_equip_value": 1000,
+                    "is_alive": True,
+                }
+            ]
+        ),
+        pd.DataFrame(
+            [
+                {
+                    "tick": 200,
+                    "name": "alpha",
+                    "team_num": 3,
+                    "current_equip_value": 2000,
+                    "is_alive": True,
+                }
+            ]
+        ),
+    ]
+    freeze_end = pd.DataFrame(
+        {"tick": [100, 200], "total_rounds_played": [0, 1]}
+    )
+
+    economy, _, _, _, ticks_df = build_round_economy_shared(
+        parser,
+        freeze_end_df=freeze_end,
+        round_start_df=pd.DataFrame({"tick": [90, 150]}),
+    )
+
+    assert parser.parse_ticks.call_count == 2
+    assert parser.parse_ticks.call_args_list[1].kwargs["ticks"] == [200]
+    assert set(ticks_df["tick"]) == {100, 200}
+    assert economy == {1: {2: 1000, 3: 0}, 2: {2: 0, 3: 2000}}
+
+
+def test_roster_and_tick_lookup_use_controller_team_fallback():
+    rows = pd.DataFrame(
+        [
+            {
+                "tick": 100,
+                "name": f"player-{i}",
+                "steamid": 76561198000000000 + i,
+                "user_id": i + 1,
+                "team_num": float("nan") if i in (0, 5) else (2 if i < 5 else 3),
+                PLAYER_CONTROLLER_TEAM_PROP: 2 if i < 5 else 3,
+            }
+            for i in range(10)
+        ]
+    )
+    roster_parser = Mock()
+    roster_parser.parse_ticks.return_value = rows
+
+    roster = _build_all_players_roster(
+        roster_parser,
+        100,
+        {},
+        {},
+        name_to_team_pi={},
+        player_ticks_df=rows,
+    )
+
+    roster_parser.parse_ticks.assert_not_called()
+    assert len(roster) == 10
+    assert [player["team_num"] for player in roster] == [2] * 5 + [3] * 5
+    assert all(player["steamid64"] for player in roster)
+
+    spec_parser = Mock()
+    slots = build_player_name_to_spec_player_slot_dict(
+        spec_parser,
+        100,
+        player_ticks_df=rows,
+    )
+    spec_parser.parse_ticks.assert_not_called()
+    assert slots["player-0"] == 1
+    assert slots["player-9"] == 10
+
+    lookup_parser = Mock()
+    lookup_parser.parse_ticks.return_value = rows
+    lookup = _build_tick_team_lookup(lookup_parser, [100])
+    assert lookup[100]["player-0"] == 2
+    assert lookup[100]["player-5"] == 3
+
+
+def test_spec_slot_does_not_reuse_a_snapshot_from_the_wrong_tick():
+    shared = pd.DataFrame(
+        {"tick": [100], "name": ["old-name"], "user_id": [1]}
+    )
+    parser = Mock()
+    parser.parse_ticks.return_value = pd.DataFrame(
+        {"tick": [200], "name": ["current-name"], "user_id": [7]}
+    )
+
+    slots = build_player_name_to_spec_player_slot_dict(
+        parser,
+        200,
+        player_ticks_df=shared,
+    )
+
+    parser.parse_ticks.assert_called_once_with(["user_id", "name"], ticks=[200])
+    assert slots == {"current-name": 7}
+
+
+def test_group_side_reuses_materialized_player_ticks():
+    parser = Mock()
+    ticks_df = pd.DataFrame(
+        [
+            {
+                "tick": 100,
+                "steamid": 1,
+                "team_num": float("nan"),
+                PLAYER_CONTROLLER_TEAM_PROP: 2,
+            },
+            {
+                "tick": 100,
+                "steamid": 2,
+                "team_num": 3,
+                PLAYER_CONTROLLER_TEAM_PROP: 3,
+            },
+            {
+                "tick": 200,
+                "steamid": 1,
+                "team_num": float("nan"),
+                PLAYER_CONTROLLER_TEAM_PROP: 3,
+            },
+            {
+                "tick": 200,
+                "steamid": 2,
+                "team_num": 2,
+                PLAYER_CONTROLLER_TEAM_PROP: 2,
+            },
+        ]
+    )
+
+    result = build_group_side_by_round(
+        parser,
+        {1: 100, 2: 200},
+        {"1": 2, "2": 3},
+        player_ticks_df=ticks_df,
+    )
+
+    parser.parse_ticks.assert_not_called()
+    assert result == {1: {2: 2, 3: 3}, 2: {2: 3, 3: 2}}
+
+
+def test_partial_spec_snapshot_retries_and_merges_missing_player_ids():
+    cached = pd.DataFrame(
+        {
+            "tick": [100, 100],
+            "name": ["alpha", "bravo"],
+            "user_id": [1, None],
+        }
+    )
+    parser = Mock()
+    parser.parse_ticks.return_value = pd.DataFrame(
+        {
+            "tick": [100, 100],
+            "name": ["alpha", "bravo"],
+            "user_id": [1, 2],
+        }
+    )
+
+    slots = build_player_name_to_spec_player_slot_dict(
+        parser,
+        100,
+        player_ticks_df=cached,
+        expected_names={"alpha", "bravo"},
+    )
+
+    parser.parse_ticks.assert_called_once_with(["user_id", "name"], ticks=[100])
+    assert slots == {"alpha": 1, "bravo": 2}
+
+
+def test_partial_roster_snapshot_retries_and_keeps_all_expected_players():
+    cached = pd.DataFrame(
+        [
+            {
+                "tick": 100,
+                "name": "alpha",
+                "steamid": 1,
+                "team_num": 2,
+            }
+        ]
+    )
+    parser = Mock()
+    parser.parse_ticks.return_value = pd.DataFrame(
+        [
+            {
+                "tick": 100,
+                "name": "alpha",
+                "steamid": 1,
+                "team_num": 2,
+            },
+            {
+                "tick": 100,
+                "name": "bravo",
+                "steamid": 2,
+                "team_num": 3,
+            },
+        ]
+    )
+
+    roster = _build_all_players_roster(
+        parser,
+        100,
+        {"alpha": 1, "bravo": 2},
+        {"alpha": 1},
+        name_to_team_pi={},
+        player_ticks_df=cached,
+    )
+
+    parser.parse_ticks.assert_called_once()
+    assert [player["name"] for player in roster] == ["alpha", "bravo"]
+    assert [player["team_num"] for player in roster] == [2, 3]
+
+
+def test_roster_repairs_expected_player_with_unusable_cached_team():
+    rows = pd.DataFrame(
+        [
+            {
+                "tick": 100,
+                "name": f"player-{index}",
+                "steamid": 76561198000000000 + index,
+                "team_num": (
+                    float("nan")
+                    if index == 4
+                    else (2 if index < 5 else 3)
+                ),
+                PLAYER_CONTROLLER_TEAM_PROP: (
+                    float("nan")
+                    if index == 4
+                    else (2 if index < 5 else 3)
+                ),
+            }
+            for index in range(10)
+        ]
+    )
+    parser = Mock()
+    parser.parse_ticks.return_value = rows
+    names = {f"player-{index}" for index in range(10)}
+
+    roster = _build_all_players_roster(
+        parser,
+        100,
+        {name: index + 1 for index, name in enumerate(sorted(names))},
+        {
+            name: 76561198000000000 + index
+            for index, name in enumerate(sorted(names))
+        },
+        name_to_team_pi={
+            name: (2 if int(name.rsplit("-", 1)[1]) < 5 else 3)
+            for name in names
+        },
+        player_ticks_df=rows,
+        expected_names=names,
+    )
+
+    parser.parse_ticks.assert_called_once()
+    assert len(roster) == 10
+    assert {player["name"] for player in roster} == names
+    repaired = next(player for player in roster if player["name"] == "player-4")
+    assert repaired["team_num"] == 2
+
+
+def test_group_side_retries_only_ticks_without_a_usable_observation():
+    cached = pd.DataFrame(
+        [
+            {"tick": 100, "steamid": 1, "team_num": 2},
+            {"tick": 100, "steamid": 2, "team_num": 3},
+        ]
+    )
+    parser = Mock()
+    parser.parse_ticks.return_value = pd.DataFrame(
+        [
+            {"tick": 200, "steamid": 1, "team_num": 3},
+            {"tick": 200, "steamid": 2, "team_num": 2},
+        ]
+    )
+
+    result = build_group_side_by_round(
+        parser,
+        {1: 100, 2: 200},
+        {"1": 2, "2": 3},
+        player_ticks_df=cached,
+    )
+
+    assert parser.parse_ticks.call_args.kwargs["ticks"] == [200]
+    assert result == {1: {2: 2, 3: 3}, 2: {2: 3, 3: 2}}
+
+
+def test_spatial_snapshot_uses_controller_team_for_alive_summary():
+    parser = Mock()
+    parser.parse_ticks.return_value = pd.DataFrame(
+        [
+            {
+                "tick": 100,
+                "name": "alpha",
+                "is_alive": True,
+                "X": 10.0,
+                "Y": 20.0,
+                "team_num": float("nan"),
+                PLAYER_CONTROLLER_TEAM_PROP: 2,
+            },
+            {
+                "tick": 100,
+                "name": "bravo",
+                "is_alive": True,
+                "X": 30.0,
+                "Y": 40.0,
+                "team_num": 3,
+                PLAYER_CONTROLLER_TEAM_PROP: 3,
+            },
+        ]
+    )
+
+    cache, alive = parse_spatial_snapshots(parser, [100])
+
+    assert cache[100]["alpha"]["team_num"] == 2
+    assert alive == {100: {2: frozenset({"alpha"}), 3: frozenset({"bravo"})}}
+    assert _alive_mates_and_enemies(
+        cache[100], "alpha", alive_by_team=alive[100],
+    ) == (0, 1)
+
+
+def test_controller_only_identity_makes_clutch_counts_unknown():
+    parser = Mock()
+    parser.parse_ticks.return_value = pd.DataFrame(
+        [
+            {
+                "tick": 100,
+                "name": "hero",
+                "is_alive": True,
+                "X": 10.0,
+                "Y": 20.0,
+                "team_num": 2,
+                PLAYER_CONTROLLER_TEAM_PROP: 2,
+            },
+            {
+                "tick": 100,
+                "name": "unresolved-mate",
+                "is_alive": False,
+                "X": float("nan"),
+                "Y": float("nan"),
+                "team_num": float("nan"),
+                PLAYER_CONTROLLER_TEAM_PROP: 2,
+            },
+            {
+                "tick": 100,
+                "name": "enemy",
+                "is_alive": True,
+                "X": 30.0,
+                "Y": 40.0,
+                "team_num": 3,
+                PLAYER_CONTROLLER_TEAM_PROP: 3,
+            },
+        ]
+    )
+
+    cache, alive = parse_spatial_snapshots(parser, [100])
+
+    assert cache[100]["unresolved-mate"]["_pawn_state_known"] is False
+    assert _alive_mates_and_enemies(
+        cache[100], "hero", alive_by_team=alive[100],
+    ) is None
+    assert _alive_mates_and_enemies(
+        cache[100], "unresolved-mate", alive_by_team=alive[100],
+    ) is None
+
+
+def test_missing_spatial_data_does_not_become_backstab():
+    tick = 100
+    cache = {
+        tick: {
+            "hero": {"X": 10.0, "Y": 10.0, "yaw": 0.0},
+            "unresolved": {
+                "X": float("nan"),
+                "Y": float("nan"),
+                "yaw": float("nan"),
+            },
+        },
+    }
+    kills = {
+        1: [{
+            "tick": tick,
+            "victim": "unresolved",
+            "weapon": "ak47",
+            "tags": [],
+        }],
+    }
+
+    assert _victim_facing_attacker(cache[tick], "hero", "unresolved") is None
+    enrich_kill_action_tags_spatial(kills, cache, "hero")
+    assert "🔙 偷背身" not in kills[1][0]["tags"]
+
+    missing_victim_kills = {
+        1: [{
+            "tick": tick,
+            "victim": "not-in-snapshot",
+            "weapon": "ak47",
+            "tags": [],
+        }],
+    }
+    assert _victim_facing_attacker(cache[tick], "hero", "not-in-snapshot") is None
+    assert _victim_facing_attacker(cache[tick], "not-in-snapshot", "hero") is None
+    enrich_kill_action_tags_spatial(missing_victim_kills, cache, "hero")
+    assert "🔙 偷背身" not in missing_victim_kills[1][0]["tags"]


### PR DESCRIPTION
## 概要

- 将共享的 Demo 事件、tick 快照、阵容数据、经济数据和空间输入一次性解析为 `SharedDemoFacts` 中间表示。
- 在一个隔离的批处理 worker 中分析所有请求的玩家，随后只进行轻量的逐玩家过滤和聚合。
- 对 pawn 队伍字段不完整或缓存事件帧部分缺失的 Demo，加入保守的兼容回退。
- 将缺失的空间观测视为未知，避免不完整的 Demo 误生成 `clutch`、`1vN` 或 `backstab` 标签。

## 性能

近期私有 Demo 的本地 10 人基准测试：

| Demo | 原批处理路径 | 共享分析 | 加速比 |
| --- | ---: | ---: | ---: |
| FACEIT A | 19.004 秒 | 4.244 秒 | 4.48x |
| FACEIT B | 31.172 秒 | 6.897 秒 | 4.52x |

共享路径在两个 FACEIT Demo 和四个完美世界 Demo（Ancient、Mirage、Inferno、Dust2）中均成功返回全部 10 名玩家，耗时为 4.2–6.9 秒。一次具有代表性的 10 人运行将顶层 demoparser API 调用次数从 145 次降至 16 次；这些调用不应被视为成本相同。

## 兼容性与正确性

- 六个 Demo 的 10 人矩阵测试中，每个 Demo 均返回 10/10 个结果。
- 在统一生成的 clip ID 后，三名玩家的共享分析结果与逐人分析结果一致。
- 正序和逆序输入玩家时，标准化后的结果等价。
- 只有当 pawn 队伍数据不可用时，才会回退使用 controller 队伍数据。
- controller 回退只恢复队伍身份，不会补造缺失的 pawn 坐标、生命值或存活状态。
- 一个完美世界样本中仍有四名玩家没有轨迹，因为当前 demoparser 暴露的是尚未解析的高位 pawn handle；这些观测会保留为未知，而不会通过推断补齐。

## 验证

- 定向 parser/API 兼容性测试：`21 passed`。
- 完整后端测试：`157 passed, 2 failed`；两项失败均为已有的 `test_fade_config_resolve.py` 失败，并已确认在基准分支上同样复现且结果不变。
- `python -m compileall -q backend/app`
- `git diff --check`

## 范围

雷达提取、Demo 库变更、语音解析、文档以及 demoparser handle 解码均不在本次范围内。私有基准 Demo 不包含在 PR 中；CI 覆盖使用合成的回归测试 fixture。此次未测量峰值 RSS；共享 DataFrame 会有意保留一部分内存，以显著减少 parser 扫描次数。
