### PR TITLE
perf(parser): 共享 Demo 检查与多玩家事件索引

### DIFF
--- a/backend/app/demo_parse_isolation.py
+++ b/backend/app/demo_parse_isolation.py
@@ -117,6 +117,17 @@ def get_demo_match_summary_isolated(dem_path: str) -> dict:
     return result
 
 
+def inspect_demo_isolated(dem_path: str) -> dict:
+    result = run_parse_worker("inspect", dem_path=dem_path)
+    if not isinstance(result, dict):
+        raise IsolatedParseError("Demo 检查 worker 返回了无效结果")
+    players = result.get("players")
+    match_meta = result.get("match_meta")
+    if not isinstance(players, list) or not isinstance(match_meta, dict):
+        raise IsolatedParseError("Demo 检查 worker 缺少玩家名单或比赛摘要")
+    return result
+
+
 def extract_radar_timeline_isolated(**kwargs: Any) -> Any:
     """parse_ticks 雷达时间线（子进程隔离，避免 demoparser 原生崩溃拖垮服务）。"""
     return run_parse_worker("radar_timeline", **kwargs)

--- a/backend/app/demo_parser.py
+++ b/backend/app/demo_parser.py
@@ -22,6 +22,7 @@ from .parser import (
     # parse_worker.py
     DemoAnalyzer,
     get_demo_match_summary,
+    inspect_demo,
     # ai_reviewer.py
     Clip,
     meme_series_badges_for_kd,

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -427,21 +427,32 @@ def _analyze_demo_sync(
     return analyze_demo_isolated(dem_path, target_player, freeze_to_death_rounds)
 
 
+def _demo_inspect_concurrency() -> int:
+    try:
+        configured = int(os.environ.get("CS2_INSIGHT_DEMO_INSPECT_CONCURRENCY", "2"))
+    except ValueError:
+        configured = 2
+    return max(1, min(4, configured))
+
+
+async def _inspect_demo_meta(dem_path: Path) -> tuple[list[dict], dict]:
+    from .demo_parse_isolation import inspect_demo_isolated
+
+    inspection = await asyncio.to_thread(inspect_demo_isolated, str(dem_path))
+    players = inspection.get("players")
+    match_meta = inspection.get("match_meta")
+    if not isinstance(players, list) or not isinstance(match_meta, dict):
+        raise ValueError("Demo inspection returned invalid metadata")
+    return players, match_meta
+
+
 async def _safe_upload_demo_meta(dem_path: Path) -> tuple[list[dict], dict]:
     """Best-effort metadata for upload responses; upload must not fail if parsing does."""
-    from .demo_parse_isolation import get_demo_match_summary_isolated, get_player_list_isolated
-
-    players: list[dict] = []
-    match_meta: dict = {}
     try:
-        players = await asyncio.to_thread(get_player_list_isolated, str(dem_path))
+        return await _inspect_demo_meta(dem_path)
     except Exception as e:  # noqa: BLE001
-        logger.exception("Upload player-list parse failed for %s: %s", dem_path, e)
-    try:
-        match_meta = await asyncio.to_thread(get_demo_match_summary_isolated, str(dem_path))
-    except Exception as e:  # noqa: BLE001
-        logger.exception("Upload summary parse failed for %s: %s", dem_path, e)
-    return players, match_meta
+        logger.exception("Upload metadata inspection failed for %s: %s", dem_path, e)
+        return [], {}
 
 
 # 监听目录按「期望玩家」自动写库展示名时串行，避免大量 demo 同时读盘
@@ -1412,17 +1423,27 @@ async def upload_demos(files: Annotated[list[UploadFile], File()]):
     """一次上传多个 .dem，返回与单文件 upload 相同结构的数组。"""
     if not files:
         raise HTTPException(400, "请至少选择一个文件")
-    out: list[dict] = []
+    saved: list[tuple[str, Path]] = []
     for file in files:
         if not file.filename or not str(file.filename).lower().endswith(".dem"):
             raise HTTPException(400, f"仅接受 .dem 文件: {file.filename!r}")
         dest = UPLOAD_DIR / file.filename
         with dest.open("wb") as f:
             shutil.copyfileobj(file.file, f)
-        players, match_meta = await _safe_upload_demo_meta(dest)
+        saved.append((file.filename, dest))
+
+    inspect_sem = asyncio.Semaphore(_demo_inspect_concurrency())
+
+    async def _inspect_one(dest: Path) -> tuple[list[dict], dict]:
+        async with inspect_sem:
+            return await _safe_upload_demo_meta(dest)
+
+    inspected = await asyncio.gather(*(_inspect_one(dest) for _, dest in saved))
+    out: list[dict] = []
+    for (filename, dest), (players, match_meta) in zip(saved, inspected):
         out.append(
             {
-                "filename": file.filename,
+                "filename": filename,
                 "path": str(dest),
                 "players": players,
                 "match_meta": match_meta,
@@ -1651,12 +1672,21 @@ def _demo_roster_source_fingerprint(demo_path: str) -> tuple[str, int | None, in
         return normalized_path, None, None
 
 
-async def index_demo_player_stats(demo_id: int, demo_path: str) -> dict[str, Any]:
+async def index_demo_player_stats(
+    demo_id: int,
+    demo_path: str,
+    *,
+    precomputed_players: Optional[list[dict[str, Any]]] = None,
+) -> dict[str, Any]:
     from .demo_parse_isolation import get_player_list_isolated
 
     normalized_path, file_size, mtime_ns = _demo_roster_source_fingerprint(demo_path)
     try:
-        raw = await asyncio.to_thread(get_player_list_isolated, demo_path)
+        raw: Any = (
+            precomputed_players
+            if precomputed_players is not None
+            else await asyncio.to_thread(get_player_list_isolated, demo_path)
+        )
         if isinstance(raw, dict):
             players = raw.get("players") or raw.get("roster") or []
         elif isinstance(raw, list):
@@ -2539,8 +2569,13 @@ async def batch_ingest_demos(body: BatchIngestBody):
     """批量入库：对每个 pending demo 运行轻量元数据提取，状态改为 loaded。"""
     ingested = 0
     failed: list[dict[str, Any]] = []
+    rows_by_id = {
+        int(row["id"]): row
+        for row in await demo_db.get_demo_list_items(body.demo_ids)
+    }
+    candidates: list[tuple[int, dict[str, Any], str]] = []
     for demo_id in body.demo_ids:
-        row = await demo_db.get_demo_by_id(demo_id)
+        row = rows_by_id.get(int(demo_id))
         if not row:
             failed.append({"demo_id": demo_id, "error": "Demo 不存在"})
             continue
@@ -2551,19 +2586,46 @@ async def batch_ingest_demos(body: BatchIngestBody):
         if not Path(dem_path).is_file():
             failed.append({"demo_id": demo_id, "filename": row.get("filename", ""), "error": "文件不存在"})
             continue
-        try:
-            from .demo_parse_isolation import get_demo_match_summary_isolated
+        candidates.append((int(demo_id), row, dem_path))
 
-            meta = await asyncio.to_thread(get_demo_match_summary_isolated, dem_path)
+    inspect_sem = asyncio.Semaphore(_demo_inspect_concurrency())
+
+    async def _inspect_candidate(
+        candidate: tuple[int, dict[str, Any], str],
+    ) -> tuple[int, dict[str, Any], str, Optional[list[dict]], Optional[dict], Optional[Exception]]:
+        demo_id, row, dem_path = candidate
+        try:
+            async with inspect_sem:
+                players, meta = await _inspect_demo_meta(Path(dem_path))
+            return demo_id, row, dem_path, players, meta, None
+        except Exception as exc:  # noqa: BLE001 - report one failed demo without cancelling the batch.
+            return demo_id, row, dem_path, None, None, exc
+
+    inspected = await asyncio.gather(*(_inspect_candidate(item) for item in candidates))
+    for demo_id, row, dem_path, players, meta, error in inspected:
+        if error is not None:
+            logger.error(
+                "Ingest inspection failed demo_id=%s path=%s: %s",
+                demo_id,
+                dem_path,
+                error,
+            )
+            failed.append({"demo_id": demo_id, "filename": row.get("filename", ""), "error": str(error)})
+            continue
+        try:
             if isinstance(meta, dict):
                 refined_source = infer_demo_source(Path(dem_path).name, server_name=meta.get("server_name"))
                 await demo_db.update_lightweight_meta(dem_path, meta, source=refined_source)
-            await index_demo_player_stats(demo_id, dem_path)
+            await index_demo_player_stats(
+                demo_id,
+                dem_path,
+                precomputed_players=players or [],
+            )
             await demo_db.update_status(dem_path, "loaded", error_msg=None, parsed_at=utc_now_iso())
             ingested += 1
-        except Exception as e:
-            logger.exception("Ingest failed demo_id=%s path=%s", demo_id, dem_path)
-            failed.append({"demo_id": demo_id, "filename": row.get("filename", ""), "error": str(e)})
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("Ingest persist failed demo_id=%s path=%s", demo_id, dem_path)
+            failed.append({"demo_id": demo_id, "filename": row.get("filename", ""), "error": str(exc)})
     if ingested:
         await demo_library_hub.notify("enqueue")
     return {"ingested": ingested, "failed": failed}

--- a/backend/app/parse_worker.py
+++ b/backend/app/parse_worker.py
@@ -9,13 +9,13 @@ from pathlib import Path
 from typing import Any, Optional
 
 if __package__:
-    from .demo_parser import DemoAnalyzer, get_demo_match_summary, get_player_list
+    from .demo_parser import DemoAnalyzer, get_demo_match_summary, get_player_list, inspect_demo
     from .radar.radar_data_extractor import extract_radar_timeline_impl
 else:
     backend_dir = Path(__file__).resolve().parents[1]
     if str(backend_dir) not in sys.path:
         sys.path.insert(0, str(backend_dir))
-    from app.demo_parser import DemoAnalyzer, get_demo_match_summary, get_player_list
+    from app.demo_parser import DemoAnalyzer, get_demo_match_summary, get_player_list, inspect_demo
     from app.radar.radar_data_extractor import extract_radar_timeline_impl
 
 
@@ -65,6 +65,8 @@ def _run(payload: dict) -> object:
         return get_player_list(dem_path)
     if action == "summary":
         return get_demo_match_summary(dem_path)
+    if action == "inspect":
+        return inspect_demo(dem_path)
     raise ValueError(f"unknown parse worker action: {action!r}")
 
 

--- a/backend/app/parser/__init__.py
+++ b/backend/app/parser/__init__.py
@@ -23,7 +23,7 @@ from .player_roster import (
     get_player_list, spec_player_extra_offset_for_gsi_failure,
     build_player_name_to_spec_player_slot_dict, lookup_spec_player_slot_for_name,
 )
-from .analyzer import DemoAnalyzer, get_demo_match_summary, collect_match_summary_metrics
+from .analyzer import DemoAnalyzer, get_demo_match_summary, inspect_demo, collect_match_summary_metrics
 
 __all__ = [
     # models
@@ -44,5 +44,5 @@ __all__ = [
     "get_player_list", "spec_player_extra_offset_for_gsi_failure",
     "build_player_name_to_spec_player_slot_dict", "lookup_spec_player_slot_for_name",
     # analyzer
-    "DemoAnalyzer", "get_demo_match_summary", "collect_match_summary_metrics",
+    "DemoAnalyzer", "get_demo_match_summary", "inspect_demo", "collect_match_summary_metrics",
 ]

--- a/backend/app/parser/analyzer.py
+++ b/backend/app/parser/analyzer.py
@@ -33,7 +33,7 @@ from .parse_utils import (
     _pick_assister_column, win_panel_ceiling_from_match_tick,
 )
 from .round_economy import (
-    build_round_economy, build_round_economy_shared, extract_target_team_map,
+    build_round_economy, build_round_economy_shared, extract_player_team_maps,
     build_round_scores, build_round_scores_team_based,
     _scoreline_by_starting_roster, _extract_team_names_from_demo,
     build_group_side_by_round, round_target_team_map_from_groups,
@@ -46,6 +46,7 @@ from .player_roster import (
     _lookup_user_id_for_name, _lookup_steam_id_for_name,
     lookup_spec_player_slot_for_name,
     build_steam_to_team_from_player_info, build_name_to_team_from_player_info,
+    get_player_list,
 )
 from .spatial_analysis import (
     parse_spatial_snapshots, _victim_facing_attacker, is_jump_kill,
@@ -61,7 +62,7 @@ from .clip_builder import (
     match_metrics_from_round_scores, is_post_match_round,
     round_start_scores_for_target, is_mr12_regulation_decided_score,
 )
-from .spatial_analysis import build_fire_index, count_shots_before
+from .spatial_analysis import count_shots_before
 
 logger = logging.getLogger(__name__)
 
@@ -93,6 +94,214 @@ class SharedDemoFacts:
     def roster_snapshot(self) -> list[dict]:
         """Return an isolated roster for one ParseResult output."""
         return [dict(player) for player in self.all_players_roster]
+
+
+@dataclass(slots=True)
+class SharedPlayerIndexes:
+    """Player-keyed Python indexes built once from shared event frames."""
+
+    equip_by_player: dict[str, tuple[tuple[int, str], ...]]
+    fire_by_player: dict[str, tuple[tuple[int, str], ...]]
+    hurt_by_attacker: dict[str, tuple[tuple[int, str, int], ...]]
+    defuse_windows_by_player: dict[str, dict[int, tuple[int, int]]]
+    round_hurt_by_victim: dict[str, dict[int, tuple[tuple[int, int, str], ...]]]
+    enemy_hurts: tuple[tuple[int, Any, str, str, int], ...]
+    team_kills: dict[int, dict[Any, dict[str, int]]]
+
+
+def _build_shared_player_indexes(
+    *,
+    events: pd.DataFrame,
+    fire_df: pd.DataFrame,
+    hurt_df: pd.DataFrame,
+    equip_df: pd.DataFrame,
+    begindefuse_df: pd.DataFrame,
+    defused_df: pd.DataFrame,
+    round_freeze_end_ticks: dict[int, int],
+) -> SharedPlayerIndexes:
+    equip_by_player: dict[str, list[tuple[int, str]]] = {}
+    if not equip_df.empty and {"user_name", "tick"}.issubset(equip_df.columns):
+        item_col = "item" if "item" in equip_df.columns else None
+        if item_col is not None:
+            for player, tick, item in equip_df[["user_name", "tick", item_col]].itertuples(
+                index=False,
+                name=None,
+            ):
+                if not isinstance(player, str):
+                    continue
+                equip_by_player.setdefault(player, []).append(
+                    (_int(tick), _normalize_item(item))
+                )
+
+    fire_by_player: dict[str, list[tuple[int, str]]] = {}
+    if not fire_df.empty and {"user_name", "tick"}.issubset(fire_df.columns):
+        columns = ["user_name", "tick"]
+        if "weapon" in fire_df.columns:
+            columns.append("weapon")
+        for values in fire_df[columns].itertuples(index=False, name=None):
+            player, tick = values[0], values[1]
+            if not isinstance(player, str):
+                continue
+            weapon = _normalize_item(values[2]) if len(values) > 2 else ""
+            fire_by_player.setdefault(player, []).append((_int(tick), weapon))
+
+    hurt_by_attacker: dict[str, list[tuple[int, str, int]]] = {}
+    round_hurt_by_victim: dict[str, dict[int, list[tuple[int, int, str]]]] = {}
+    enemy_hurts: list[tuple[int, Any, str, str, int]] = []
+    if not hurt_df.empty and {"attacker_name", "user_name", "tick"}.issubset(hurt_df.columns):
+        round_damage_col = next(
+            (name for name in ("dmg_health", "damage", "health_damage") if name in hurt_df.columns),
+            None,
+        )
+        columns = ["attacker_name", "user_name", "tick"]
+        for optional_column in (
+            round_damage_col,
+            "weapon" if "weapon" in hurt_df.columns else None,
+            "total_rounds_played" if "total_rounds_played" in hurt_df.columns else None,
+            "attacker_team" if "attacker_team" in hurt_df.columns else None,
+            "user_team" if "user_team" in hurt_df.columns else None,
+        ):
+            if optional_column and optional_column not in columns:
+                columns.append(optional_column)
+        positions = {name: index for index, name in enumerate(columns)}
+        freeze_ticks_desc = sorted(
+            ((int(tick), int(round_number)) for round_number, tick in round_freeze_end_ticks.items()),
+            reverse=True,
+        )
+        has_team_columns = "attacker_team" in positions and "user_team" in positions
+        for values in hurt_df[columns].itertuples(index=False, name=None):
+            attacker_raw = values[positions["attacker_name"]]
+            victim_raw = values[positions["user_name"]]
+            attacker = str(attacker_raw or "").strip()
+            victim = str(victim_raw or "").strip()
+            tick = _int(values[positions["tick"]])
+            round_damage = (
+                _int(values[positions[round_damage_col]]) if round_damage_col else 0
+            )
+            weapon = (
+                _normalize_item(values[positions["weapon"]])
+                if "weapon" in positions
+                else ""
+            )
+            # Keep build_hurt_index's legacy contract: fail-tag damage only
+            # exists when demoparser supplied dmg_health specifically.
+            if attacker and "dmg_health" in positions:
+                hurt_by_attacker.setdefault(attacker, []).append(
+                    (tick, victim, _int(values[positions["dmg_health"]]))
+                )
+
+            event_round_number = 0
+            if "total_rounds_played" in positions:
+                event_round_number = _int(values[positions["total_rounds_played"]]) + 1
+            round_number = event_round_number
+            if round_number <= 0 and tick > 0:
+                round_number = next(
+                    (rn for freeze_tick, rn in freeze_ticks_desc if tick >= freeze_tick),
+                    0,
+                )
+            if victim and round_number > 0:
+                round_hurt_by_victim.setdefault(victim, {}).setdefault(
+                    round_number,
+                    [],
+                ).append((tick, round_damage, weapon))
+
+            if not attacker or not victim or attacker == victim:
+                continue
+            attacker_team: Any = None
+            if has_team_columns:
+                raw_attacker_team = values[positions["attacker_team"]]
+                raw_victim_team = values[positions["user_team"]]
+                try:
+                    if raw_attacker_team == raw_victim_team:
+                        continue
+                    attacker_team = raw_attacker_team
+                except Exception:
+                    attacker_team = None
+            # The teammate filter historically used only the event's explicit
+            # round field.  Do not feed its freeze-tick fallback into that path.
+            enemy_hurts.append(
+                (event_round_number, attacker_team, attacker, victim, tick)
+            )
+
+    begin_by_player: dict[str, dict[int, int]] = {}
+    if (
+        not begindefuse_df.empty
+        and {"user_name", "tick", "total_rounds_played"}.issubset(begindefuse_df.columns)
+    ):
+        for player, tick, rounds_played in begindefuse_df[
+            ["user_name", "tick", "total_rounds_played"]
+        ].itertuples(index=False, name=None):
+            player_name = str(player or "").strip()
+            begin_tick = _int(tick)
+            round_number = _int(rounds_played) + 1
+            if player_name and begin_tick > 0 and round_number > 0:
+                begin_by_player.setdefault(player_name, {}).setdefault(round_number, begin_tick)
+
+    defuse_windows_by_player: dict[str, dict[int, tuple[int, int]]] = {}
+    if not defused_df.empty and {"user_name", "tick"}.issubset(defused_df.columns):
+        for player, tick in defused_df[["user_name", "tick"]].itertuples(
+            index=False,
+            name=None,
+        ):
+            player_name = str(player or "").strip()
+            defuse_tick = _int(tick)
+            player_begins = begin_by_player.get(player_name, {})
+            player_windows = defuse_windows_by_player.setdefault(player_name, {})
+            for round_number, begin_tick in player_begins.items():
+                if 0 < begin_tick <= defuse_tick and round_number not in player_windows:
+                    player_windows[round_number] = (begin_tick, defuse_tick)
+                    break
+
+    team_kills: dict[int, dict[Any, dict[str, int]]] = {}
+    if not events.empty:
+        required = {"attacker_name", "user_name", "total_rounds_played"}
+        if required.issubset(events.columns):
+            columns = ["attacker_name", "user_name", "total_rounds_played"]
+            for optional_column in ("attackerteam", "userteam"):
+                if optional_column in events.columns:
+                    columns.append(optional_column)
+            positions = {name: index for index, name in enumerate(columns)}
+            for values in events[columns].itertuples(index=False, name=None):
+                attacker = str(values[positions["attacker_name"]] or "").strip()
+                victim = str(values[positions["user_name"]] or "").strip()
+                if not attacker or attacker == victim:
+                    continue
+                attacker_team = values[positions["attackerteam"]] if "attackerteam" in positions else None
+                victim_team = values[positions["userteam"]] if "userteam" in positions else None
+                try:
+                    if attacker_team is None or attacker_team == victim_team:
+                        continue
+                    hash(attacker_team)
+                except Exception:
+                    continue
+                round_number = _int(values[positions["total_rounds_played"]]) + 1
+                if round_number <= 0:
+                    continue
+                player_counts = team_kills.setdefault(round_number, {}).setdefault(
+                    attacker_team,
+                    {},
+                )
+                player_counts[attacker] = player_counts.get(attacker, 0) + 1
+
+    for values_by_player in (equip_by_player, fire_by_player, hurt_by_attacker):
+        for values in values_by_player.values():
+            values.sort(key=lambda item: item[0])
+    for by_round in round_hurt_by_victim.values():
+        for values in by_round.values():
+            values.sort()
+
+    return SharedPlayerIndexes(
+        equip_by_player={name: tuple(values) for name, values in equip_by_player.items()},
+        fire_by_player={name: tuple(values) for name, values in fire_by_player.items()},
+        hurt_by_attacker={name: tuple(values) for name, values in hurt_by_attacker.items()},
+        defuse_windows_by_player=defuse_windows_by_player,
+        round_hurt_by_victim={
+            name: {round_number: tuple(values) for round_number, values in by_round.items()}
+            for name, by_round in round_hurt_by_victim.items()
+        },
+        enemy_hurts=tuple(enemy_hurts),
+        team_kills=team_kills,
+    )
 
 
 def _world_self_kill_cluster_c4_surrogate_keys(
@@ -635,6 +844,22 @@ class DemoAnalyzer:
         pickup_df  = _shared["pickup_df"]
         planted_df = _shared["planted_df"]
         defused_df = _shared["defused_df"]
+        round_freeze_end_ticks_shared = _shared["round_freeze_end_ticks_shared"]
+
+        shared_player_indexes = _build_shared_player_indexes(
+            events=_shared["events"],
+            fire_df=fire_df,
+            hurt_df=_shared["hurt_df"],
+            equip_df=_shared["equip_df"],
+            begindefuse_df=_shared["begindefuse_df"],
+            defused_df=defused_df,
+            round_freeze_end_ticks=round_freeze_end_ticks_shared,
+        )
+        player_team_maps = extract_player_team_maps(
+            _shared["economy_ticks_df"],
+            _shared["tick_to_round_shared"],
+            target_players=players,
+        )
 
         _awp_fire_index: dict[str, list[int]] = {}
         if not fire_df.empty and "user_name" in fire_df.columns and "weapon" in fire_df.columns:
@@ -711,11 +936,9 @@ class DemoAnalyzer:
 
         for target_player in players:
             round_economy_map      = _shared["economy_map_shared"]
-            round_freeze_end_ticks = _shared["round_freeze_end_ticks_shared"]
+            round_freeze_end_ticks = round_freeze_end_ticks_shared
             round_freeze_start_ticks = _shared["round_freeze_start_ticks_shared"]
-            round_target_team_map  = extract_target_team_map(
-                _shared["economy_ticks_df"], _shared["tick_to_round_shared"], target_player,
-            )
+            round_target_team_map = player_team_maps.get(target_player.lower(), {})
             # extract_target_team_map 依赖逐 tick team_num；坏数据 demo 上会近乎为空。
             # 覆盖率不足时改用 parse_player_info + 每回合阵营表重建目标逐回合阵营。
             _grp_side = _shared.get("group_side_by_round_shared") or {}
@@ -742,7 +965,32 @@ class DemoAnalyzer:
                     elif opp_after > opp_before:
                         round_result_map[rnd] = False
 
-            _fire_index_full = build_fire_index(target_player, fire_df)
+            _fire_index_full = shared_player_indexes.fire_by_player.get(target_player, ())
+
+            teammate_kills_per_round: dict[int, int] = {}
+            for round_number, team_counts in shared_player_indexes.team_kills.items():
+                target_team = round_target_team_map.get(round_number)
+                if target_team is None:
+                    continue
+                player_counts = team_counts.get(target_team, {})
+                teammate_kills = sum(player_counts.values()) - player_counts.get(target_player, 0)
+                if teammate_kills > 0:
+                    teammate_kills_per_round[round_number] = teammate_kills
+
+            teammate_hurt_victim_index: dict[str, list[int]] = {}
+            for round_number, attacker_team, attacker, victim, hurt_tick in shared_player_indexes.enemy_hurts:
+                if attacker == target_player:
+                    continue
+                target_team = round_target_team_map.get(round_number)
+                if (
+                    attacker_team is not None
+                    and target_team is not None
+                    and attacker_team != target_team
+                ):
+                    continue
+                teammate_hurt_victim_index.setdefault(victim, []).append(hurt_tick)
+            for victim_ticks in teammate_hurt_victim_index.values():
+                victim_ticks.sort()
 
             # ── 从预算好的桶直接消费 ──
             round_kills: dict[int, list[dict]] = {}
@@ -887,6 +1135,13 @@ class DemoAnalyzer:
                 "round_first_death_tick":   round_first_death_tick,
                 "round_target_kill_ticks":  round_target_kill_ticks,
                 "target_total_kills":       target_total_kills,
+                "equip_timeline": shared_player_indexes.equip_by_player.get(target_player, ()),
+                "fire_index": _fire_index_full,
+                "hurt_index": shared_player_indexes.hurt_by_attacker.get(target_player, ()),
+                "defuse_window_map": shared_player_indexes.defuse_windows_by_player.get(target_player, {}),
+                "round_hurt_on_target_index": shared_player_indexes.round_hurt_by_victim.get(target_player, {}),
+                "teammate_hurt_victim_index": teammate_hurt_victim_index,
+                "teammate_kills_per_round": teammate_kills_per_round,
             }
 
         # Phase 3: Parse spatial ticks ONCE (union of all players)
@@ -911,6 +1166,13 @@ class DemoAnalyzer:
                 round_first_death_tick=ctx["round_first_death_tick"],
                 round_target_kill_ticks=ctx["round_target_kill_ticks"],
                 target_total_kills=ctx["target_total_kills"],
+                equip_timeline=ctx["equip_timeline"],
+                fire_index=ctx["fire_index"],
+                hurt_index=ctx["hurt_index"],
+                defuse_window_map=ctx["defuse_window_map"],
+                round_hurt_on_target_index=ctx["round_hurt_on_target_index"],
+                teammate_hurt_victim_index=ctx["teammate_hurt_victim_index"],
+                teammate_kills_per_round=ctx["teammate_kills_per_round"],
                 spatial_cache=spatial_cache,
                 alive_summary=alive_summary,
                 events=_shared["events"],
@@ -920,7 +1182,6 @@ class DemoAnalyzer:
                 planted_df=_shared["planted_df"],
                 defused_df=_shared["defused_df"],
                 bomb_exploded_df=_shared["bomb_exploded_df"],
-                begindefuse_df=_shared["begindefuse_df"],
                 nade_batch=_shared["nade_batch"],
                 re_df_cached=_shared["re_df_cached"],
                 win_panel_match_tick=_shared["win_panel_match_tick"],
@@ -948,6 +1209,13 @@ class DemoAnalyzer:
         round_first_death_tick: dict,
         round_target_kill_ticks: dict,
         target_total_kills: int,
+        equip_timeline: tuple[tuple[int, str], ...],
+        fire_index: tuple[tuple[int, str], ...],
+        hurt_index: tuple[tuple[int, str, int], ...],
+        defuse_window_map: dict[int, tuple[int, int]],
+        round_hurt_on_target_index: dict[int, tuple[tuple[int, int, str], ...]],
+        teammate_hurt_victim_index: dict[str, list[int]],
+        teammate_kills_per_round: dict[int, int],
         spatial_cache: dict,
         alive_summary: "Optional[dict[int, dict[int, frozenset]]]" = None,
         events: "pd.DataFrame",
@@ -957,7 +1225,6 @@ class DemoAnalyzer:
         planted_df: "pd.DataFrame",
         defused_df: "pd.DataFrame",
         bomb_exploded_df: "pd.DataFrame",
-        begindefuse_df: "pd.DataFrame",
         nade_batch: dict,
         re_df_cached: "pd.DataFrame",
         win_panel_match_tick: int = 0,
@@ -1044,36 +1311,6 @@ class DemoAnalyzer:
                 for rn, ks in round_kills.items()
             }
 
-        # defuse_window_map（使用已批量解析的 _begindefuse_df）
-        defuse_window_map: dict[int, tuple[int, int]] = {}
-        try:
-            _bd = begindefuse_df
-            if not _bd.empty and "user_name" in _bd.columns:
-                _bd = _bd.copy()
-                _bd["user_name"] = _bd["user_name"].astype(str).str.strip()
-            if not _bd.empty and "tick" in _bd.columns and "total_rounds_played" in _bd.columns:
-                _begin_map: dict[int, int] = {}
-                for _, _br in _bd.iterrows():
-                    _u = str(_br.get("user_name") or "")
-                    if _u != target_player:
-                        continue
-                    _bt = _int(_br.get("tick"))
-                    _rn = _int(_br.get("total_rounds_played")) + 1
-                    if _bt > 0 and _rn > 0 and _rn not in _begin_map:
-                        _begin_map[_rn] = _bt
-                if not defused_df.empty and "tick" in defused_df.columns:
-                    for _, _dr in defused_df.iterrows():
-                        _u = str(_dr.get("user_name") or "")
-                        if _u != target_player:
-                            continue
-                        _dt = _int(_dr.get("tick"))
-                        for _rn, _bt in _begin_map.items():
-                            if 0 < _bt <= _dt and _rn not in defuse_window_map:
-                                defuse_window_map[_rn] = (_bt, _dt)
-                                break
-        except Exception:
-            pass
-
         # prev_round_killers_of_target
         prev_round_killers_of_target: dict[int, set[str]] = {}
         round_death_tick_map: dict[int, int] = {}
@@ -1086,82 +1323,15 @@ class DemoAnalyzer:
             if _rn > 0 and _dt > 0:
                 round_death_tick_map[_rn] = _dt
 
-        # teammate_hurt_victim_index
-        teammate_hurt_victim_index: dict[str, list[int]] = {}
-        if not hurt_df.empty and {"attacker_name", "user_name", "tick"}.issubset(hurt_df.columns):
-            team_col_a = "attacker_team" if "attacker_team" in hurt_df.columns else None
-            team_col_u = "user_team" if "user_team" in hurt_df.columns else None
-            for _, _hr in hurt_df.iterrows():
-                _atk = str(_hr.get("attacker_name") or "").strip()
-                _vic = str(_hr.get("user_name") or "").strip()
-                if not _atk or not _vic or _atk == target_player or _atk == _vic:
-                    continue
-                if team_col_a is not None and team_col_u is not None:
-                    try:
-                        if _hr.get(team_col_a) != _hr.get(team_col_u):
-                            _rn = _int(_hr.get("total_rounds_played")) + 1 if "total_rounds_played" in hurt_df.columns else 0
-                            _tgt_team = round_target_team_map.get(_rn)
-                            if _tgt_team is not None and _hr.get(team_col_a) != _tgt_team:
-                                continue
-                        else:
-                            continue
-                    except Exception:
-                        pass
-                teammate_hurt_victim_index.setdefault(_vic, []).append(_int(_hr.get("tick")))
-        for _v in teammate_hurt_victim_index:
-            teammate_hurt_victim_index[_v].sort()
-
-        # teammate_kills_per_round
-        teammate_kills_per_round: dict[int, int] = {}
-        if not events.empty:
-            for _, _er in events.iterrows():
-                _atk = str(_er.get("attacker_name") or "").strip()
-                _vic = str(_er.get("user_name") or "").strip()
-                if not _atk or _atk == _vic or _atk == target_player:
-                    continue
-                _rn = _int(_er.get("total_rounds_played")) + 1
-                _tgt_team = round_target_team_map.get(_rn)
-                _atk_team = _er.get("attackerteam")
-                _vic_team = _er.get("userteam")
-                if _tgt_team is not None and _atk_team == _tgt_team and _atk_team != _vic_team:
-                    teammate_kills_per_round[_rn] = teammate_kills_per_round.get(_rn, 0) + 1
-
-        # round_hurt_on_target_index
-        round_hurt_on_target_index: dict[int, list[tuple[int, int, str]]] = {}
-        if not hurt_df.empty and "user_name" in hurt_df.columns:
-            tick_to_round: dict[int, int] = {}
-            for rn in round_freeze_end_ticks:
-                tick_to_round[int(round_freeze_end_ticks[rn])] = rn
-            for _, _hr in hurt_df.iterrows():
-                if str(_hr.get("user_name") or "") != target_player:
-                    continue
-                _ht = _int(_hr.get("tick"))
-                _hd = 0
-                for _dc in ("dmg_health", "damage", "health_damage"):
-                    if _dc in hurt_df.columns:
-                        _hd = _int(_hr.get(_dc))
-                        break
-                _hw = _normalize_item(_hr.get("weapon", ""))
-                _rn = 0
-                if "total_rounds_played" in hurt_df.columns:
-                    _rn = _int(_hr.get("total_rounds_played")) + 1
-                if _rn <= 0 and _ht > 0:
-                    for freeze_tick in sorted(round_freeze_end_ticks.values(), reverse=True):
-                        if _ht >= freeze_tick:
-                            _rn = tick_to_round.get(freeze_tick, 0)
-                            if _rn > 0:
-                                break
-                if _rn > 0:
-                    round_hurt_on_target_index.setdefault(_rn, []).append((_ht, _hd, _hw))
-        for _rn in round_hurt_on_target_index:
-            round_hurt_on_target_index[_rn].sort()
-
         # ── 构建下饭片段 ──
         fail_clips, fail_death_keys = build_fail_clips(
             target_player, death_records, equip_df, fire_df, hurt_df,
             spatial_cache, round_target_kill_ticks, round_team_score_map,
             round_result_map, round_freeze_end_ticks,
             map_name=map_name, grenade_detonate_points=grenade_detonate_points,
+            precomputed_equip_timeline=equip_timeline,
+            precomputed_fire_index=fire_index,
+            precomputed_hurt_index=hurt_index,
         )
         target_total_deaths = len(death_records)
 
@@ -1841,7 +2011,15 @@ def collect_match_summary_metrics(
     return team_a_score, team_b_score, match_date, duration_mins, total_rounds_est, team_a_name, team_b_name
 
 
-def get_demo_match_summary(dem_path: str | Path) -> dict[str, object]:
+def get_demo_match_summary(
+    dem_path: str | Path,
+    *,
+    parser: Optional[DemoParser] = None,
+    match_start_tick: Optional[int] = None,
+    death_events: Optional[pd.DataFrame] = None,
+    round_end_df: Optional[pd.DataFrame] = None,
+    header: Optional[dict] = None,
+) -> dict[str, object]:
     """上传后即刻可用的比赛摘要（无需选定玩家）。"""
     path = Path(dem_path)
     fallback: dict[str, object] = {
@@ -1853,11 +2031,22 @@ def get_demo_match_summary(dem_path: str | Path) -> dict[str, object]:
         "win_panel_match_tick": 0,
     }
     try:
-        parser = DemoParser(str(path))
-        mst = _get_match_start_tick(parser)
-        ta, tb, md, dm, tr_est, tan, tbn = collect_match_summary_metrics(parser, path, mst)
+        parser = parser or DemoParser(str(path))
+        mst = (
+            int(match_start_tick)
+            if match_start_tick is not None
+            else _get_match_start_tick(parser)
+        )
+        ta, tb, md, dm, tr_est, tan, tbn = collect_match_summary_metrics(
+            parser,
+            path,
+            mst,
+            death_events=death_events,
+            round_end_df=round_end_df,
+            header=header,
+        )
         try:
-            hdr = parser.parse_header()
+            hdr = header if header is not None else parser.parse_header()
             mn = hdr.get("map_name", "unknown") or "unknown"
             sn_raw = hdr.get("server_name")
             sn = str(sn_raw).strip() if sn_raw is not None else ""
@@ -1882,3 +2071,52 @@ def get_demo_match_summary(dem_path: str | Path) -> dict[str, object]:
             "get_demo_match_summary: unreadable or corrupt demo %s (%s)", path, type(e).__name__,
         )
         return dict(fallback)
+
+
+def inspect_demo(dem_path: str | Path) -> dict[str, object]:
+    """Return upload/library metadata from one parser and one shared event scan."""
+    path = Path(dem_path)
+    parser = DemoParser(str(path))
+
+    try:
+        parsed_header = parser.parse_header()
+        header = parsed_header if isinstance(parsed_header, dict) else {}
+    except BaseException as exc:
+        if isinstance(exc, (KeyboardInterrupt, SystemExit, GeneratorExit)):
+            raise
+        header = {}
+
+    batch = safe_parse_events_batch(
+        parser,
+        ["player_death", "round_end", "round_announce_match_start"],
+        player=["user_id"],
+        other=list(_EXTRA_EVENT_FIELDS) + ["winner", "reason"],
+    )
+    deaths = batch["player_death"]
+    round_ends = batch["round_end"]
+    match_start_df = batch["round_announce_match_start"]
+    match_start_tick = _get_match_start_tick(parser, precomputed_df=match_start_df)
+
+    try:
+        player_info_df = _to_pandas_df(parser.parse_player_info())
+    except BaseException as exc:
+        if isinstance(exc, (KeyboardInterrupt, SystemExit, GeneratorExit)):
+            raise
+        player_info_df = pd.DataFrame()
+
+    players = get_player_list(
+        path,
+        parser=parser,
+        match_start_tick=match_start_tick,
+        death_events=deaths,
+        player_info_df=player_info_df,
+    )
+    match_meta = get_demo_match_summary(
+        path,
+        parser=parser,
+        match_start_tick=match_start_tick,
+        death_events=deaths,
+        round_end_df=round_ends,
+        header=header,
+    )
+    return {"players": players, "match_meta": match_meta}

--- a/backend/app/parser/clip_builder.py
+++ b/backend/app/parser/clip_builder.py
@@ -318,11 +318,28 @@ def build_fail_clips(
     *,
     map_name: str,
     grenade_detonate_points: Optional[list[tuple[int, float, float]]] = None,
+    precomputed_equip_timeline: Optional[list[tuple[int, str]] | tuple[tuple[int, str], ...]] = None,
+    precomputed_fire_index: Optional[list[tuple[int, str]] | tuple[tuple[int, str], ...]] = None,
+    precomputed_hurt_index: Optional[
+        list[tuple[int, str, int]] | tuple[tuple[int, str, int], ...]
+    ] = None,
 ) -> tuple[list[Clip], set[tuple[int, int]]]:
-    equip_timeline = build_equip_timeline(target_player, equip_df)
+    equip_timeline = (
+        precomputed_equip_timeline
+        if precomputed_equip_timeline is not None
+        else build_equip_timeline(target_player, equip_df)
+    )
     from .spatial_analysis import build_fire_index, build_hurt_index
-    fire_index = build_fire_index(target_player, fire_df)
-    hurt_index = build_hurt_index(target_player, hurt_df)
+    fire_index = (
+        precomputed_fire_index
+        if precomputed_fire_index is not None
+        else build_fire_index(target_player, fire_df)
+    )
+    hurt_index = (
+        precomputed_hurt_index
+        if precomputed_hurt_index is not None
+        else build_hurt_index(target_player, hurt_df)
+    )
 
     clips: list[Clip] = []
     fail_death_keys: set[tuple[int, int]] = set()

--- a/backend/app/parser/player_roster.py
+++ b/backend/app/parser/player_roster.py
@@ -666,13 +666,25 @@ def compute_spec_player_slot_one_based(
     return (leg + off) if leg is not None else None
 
 
-def get_player_list(dem_path: str | Path) -> list[dict]:
+def get_player_list(
+    dem_path: str | Path,
+    *,
+    parser: Optional[DemoParser] = None,
+    match_start_tick: Optional[int] = None,
+    death_events: Optional[pd.DataFrame] = None,
+    player_info_df: Optional[pd.DataFrame] = None,
+) -> list[dict]:
     """扫描 Demo 所有在 player_death 出现过的玩家，汇总 K/D/A 与队伍。"""
-    parser = DemoParser(str(dem_path))
-    match_start_tick = _get_match_start_tick(parser)
+    parser = parser or DemoParser(str(dem_path))
+    if match_start_tick is None:
+        match_start_tick = _get_match_start_tick(parser)
     # 单次扫描同时取 user_id + steamid + 所有默认列（3次扫描合1次）
     try:
-        events = _to_pandas_df(parser.parse_event("player_death", player=["user_id"]))
+        events = (
+            death_events
+            if death_events is not None and not death_events.empty
+            else _to_pandas_df(parser.parse_event("player_death", player=["user_id"]))
+        )
     except BaseException as e:
         if isinstance(e, _DEMOPARSER_RE_RAISE):
             raise
@@ -800,7 +812,11 @@ def get_player_list(dem_path: str | Path) -> list[dict]:
     player_info_team_by_name: dict[str, int] = {}
     player_info_team_by_sid: dict[str, int] = {}
     try:
-        pi = _to_pandas_df(parser.parse_player_info())
+        pi = (
+            player_info_df
+            if player_info_df is not None and not player_info_df.empty
+            else _to_pandas_df(parser.parse_player_info())
+        )
     except BaseException as e:
         if isinstance(e, _DEMOPARSER_RE_RAISE):
             raise

--- a/backend/app/parser/round_economy.py
+++ b/backend/app/parser/round_economy.py
@@ -187,20 +187,46 @@ def extract_target_team_map(
     target_player: str,
 ) -> dict[int, int]:
     """Per-player: which team the player was on each round, derived from the shared economy_ticks_df."""
-    target_team_map: dict[int, int] = {}
-    if economy_ticks_df.empty or "tick" not in economy_ticks_df.columns:
-        return target_team_map
-    tp = str(target_player or "").strip().lower()
-    if not tp:
-        return target_team_map
+    target_key = str(target_player or "").strip().lower()
+    if not target_key:
+        return {}
+    return extract_player_team_maps(
+        economy_ticks_df,
+        tick_to_round,
+        target_players=[target_player],
+    ).get(target_key, {})
+
+
+def extract_player_team_maps(
+    economy_ticks_df: pd.DataFrame,
+    tick_to_round: dict[int, int],
+    *,
+    target_players: Optional[list[str]] = None,
+) -> dict[str, dict[int, int]]:
+    """Build all requested per-round player team maps in one grouped pass."""
+    target_team_maps: dict[str, dict[int, int]] = {}
+    if (
+        economy_ticks_df.empty
+        or "tick" not in economy_ticks_df.columns
+        or "team_num" not in economy_ticks_df.columns
+    ):
+        return target_team_maps
     name_col = "name" if "name" in economy_ticks_df.columns else None
     if name_col is None:
-        return target_team_map
+        return target_team_maps
+
+    requested = {
+        str(player or "").strip().lower()
+        for player in (target_players or [])
+        if str(player or "").strip()
+    }
+    if requested:
+        target_team_maps = {player: {} for player in requested}
 
     for tick, grp in economy_ticks_df.groupby("tick", sort=False):
         tick_i = int(tick)
         rn = tick_to_round.get(tick_i)
-        if rn is None or rn in target_team_map:
+        if rn is None:
             continue
         if "is_alive" in grp.columns:
             alive = grp[grp["is_alive"].astype(bool)]
@@ -209,20 +235,29 @@ def extract_target_team_map(
         search_groups = [alive, grp] if (
             "is_alive" in grp.columns and len(alive) < len(grp)
         ) else [alive]
-        for sg in search_groups:
-            if rn in target_team_map:
-                break
-            for _, r in sg.iterrows():
-                nm = str(r.get(name_col) or "").strip().lower()
-                if nm != tp:
+        for search_group in search_groups:
+            # Match the legacy per-player lookup: only the first observation
+            # for a player in each preferred/fallback group is considered.
+            seen_players: set[str] = set()
+            for name, team_num in search_group[[name_col, "team_num"]].itertuples(
+                index=False,
+                name=None,
+            ):
+                player_key = str(name or "").strip().lower()
+                if not player_key or (requested and player_key not in requested):
+                    continue
+                if player_key in seen_players:
+                    continue
+                seen_players.add(player_key)
+                player_map = target_team_maps.setdefault(player_key, {})
+                if rn in player_map:
                     continue
                 try:
-                    target_team_map[rn] = int(float(r["team_num"]))
+                    player_map[rn] = int(float(team_num))
                 except (TypeError, ValueError):
                     pass
-                break
 
-    return target_team_map
+    return target_team_maps
 
 
 def build_round_economy(

--- a/backend/app/parser/spatial_analysis.py
+++ b/backend/app/parser/spatial_analysis.py
@@ -301,37 +301,52 @@ def parse_spatial_snapshots(
         )
         df = coalesce_player_team_num(raw_df)
         df["_team_from_controller"] = controller_only_team
-        if df.empty:
+        if df.empty or "tick" not in df.columns:
             return {}, {}
+
+        # Materializing every row through ``iterrows`` creates a pandas Series
+        # per player/tick sample.  A full 10-player analysis can contain well
+        # over 100k samples, so keep the same stable per-tick ordering while
+        # traversing the frame once as plain tuples.
+        df = df.sort_values("tick", kind="mergesort")
+        columns = list(df.columns)
+        column_index = {column: index for index, column in enumerate(columns)}
+        tick_index = column_index["tick"]
+        name_index = column_index.get("name")
+
         cache: dict[int, dict[str, dict]] = {}
-        alive_summary: dict[int, dict[int, frozenset]] = {}
-        for tick, group in df.groupby("tick"):
-            tick_dict: dict[str, dict] = {}
-            by_team: dict[int, set] = {}
-            for _, row in group.iterrows():
-                name = str(row.get("name") or "").strip()
-                if name:
-                    row_d = row.to_dict()
-                    try:
-                        has_pawn_position = all(
-                            math.isfinite(float(row_d[key])) for key in ("X", "Y")
-                        )
-                    except (TypeError, ValueError, KeyError):
-                        has_pawn_position = False
-                    row_d["_pawn_state_known"] = not (
-                        bool(row_d.get("_team_from_controller"))
-                        and not has_pawn_position
-                    )
-                    tick_dict[name] = row_d
-                    if row_d["_pawn_state_known"] and row_d.get("is_alive"):
-                        try:
-                            tm = int(float(row_d["team_num"]))
-                            by_team.setdefault(tm, set()).add(name)
-                        except (TypeError, ValueError, KeyError):
-                            pass
-            tick_i = int(tick)
-            cache[tick_i] = tick_dict
-            alive_summary[tick_i] = {tm: frozenset(names) for tm, names in by_team.items()}
+        alive_names: dict[int, dict[int, set[str]]] = {}
+        for values in df.itertuples(index=False, name=None):
+            tick_i = int(values[tick_index])
+            tick_dict = cache.setdefault(tick_i, {})
+            by_team = alive_names.setdefault(tick_i, {})
+
+            name = "" if name_index is None else str(values[name_index] or "").strip()
+            if not name:
+                continue
+
+            row_d = dict(zip(columns, values))
+            try:
+                has_pawn_position = all(
+                    math.isfinite(float(row_d[key])) for key in ("X", "Y")
+                )
+            except (TypeError, ValueError, KeyError):
+                has_pawn_position = False
+            row_d["_pawn_state_known"] = not (
+                bool(row_d.get("_team_from_controller")) and not has_pawn_position
+            )
+            tick_dict[name] = row_d
+            if row_d["_pawn_state_known"] and row_d.get("is_alive"):
+                try:
+                    tm = int(float(row_d["team_num"]))
+                    by_team.setdefault(tm, set()).add(name)
+                except (TypeError, ValueError, KeyError):
+                    pass
+
+        alive_summary = {
+            tick: {team: frozenset(names) for team, names in by_team.items()}
+            for tick, by_team in alive_names.items()
+        }
         return cache, alive_summary
     except Exception:
         return {}, {}

--- a/backend/tests/test_analyzer_shared_ir.py
+++ b/backend/tests/test_analyzer_shared_ir.py
@@ -7,13 +7,18 @@ import pandas as pd
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from app.parser import analyzer as analyzer_module
-from app.parser.analyzer import DemoAnalyzer
+from app.parser.analyzer import DemoAnalyzer, _build_shared_player_indexes
 from app.parser.parse_utils import _max_demo_tick
 from app.parser.player_roster import (
     build_player_name_to_steam_id,
     build_player_name_to_user_id,
 )
 from app.parser.round_economy import build_round_scores
+from app.parser.spatial_analysis import (
+    build_equip_timeline,
+    build_fire_index,
+    build_hurt_index,
+)
 
 
 class _ParserMustNotRun:
@@ -379,3 +384,111 @@ def test_shared_facts_materialize_event_indexes_and_copy_rosters(monkeypatch):
 def test_per_player_finish_path_has_no_native_parser_access():
     source = inspect.getsource(DemoAnalyzer._finish_single_player_analysis)
     assert "self.parser" not in source
+
+
+def test_shared_player_indexes_match_legacy_player_indexes():
+    equip = pd.DataFrame([
+        {"user_name": "alpha", "tick": 30, "item": "weapon_ak47"},
+        {"user_name": "bravo", "tick": 20, "item": "weapon_m4a1"},
+        {"user_name": "alpha", "tick": 10, "item": "weapon_knife"},
+    ])
+    fire = pd.DataFrame([
+        {"user_name": "alpha", "tick": 35, "weapon": "weapon_ak47"},
+        {"user_name": "alpha", "tick": 15, "weapon": "weapon_glock"},
+        {"user_name": "bravo", "tick": 25, "weapon": "weapon_m4a1"},
+    ])
+    hurt = pd.DataFrame([
+        {
+            "attacker_name": "alpha",
+            "user_name": "enemy",
+            "tick": 40,
+            "dmg_health": 30,
+            "weapon": "weapon_ak47",
+            "total_rounds_played": 0,
+            "attacker_team": 2,
+            "user_team": 3,
+        },
+        {
+            "attacker_name": "bravo",
+            "user_name": "enemy",
+            "tick": 20,
+            "dmg_health": 12,
+            "weapon": "weapon_m4a1",
+            "total_rounds_played": 0,
+            "attacker_team": 2,
+            "user_team": 3,
+        },
+        {
+            "attacker_name": "alpha",
+            "user_name": "enemy-two",
+            "tick": 10,
+            "dmg_health": 18,
+            "weapon": "weapon_glock",
+            "total_rounds_played": 1,
+            "attacker_team": 2,
+            "user_team": 3,
+        },
+    ])
+    deaths = pd.DataFrame([
+        {
+            "attacker_name": "alpha",
+            "user_name": "enemy",
+            "total_rounds_played": 0,
+            "attackerteam": 2,
+            "userteam": 3,
+        },
+        {
+            "attacker_name": "bravo",
+            "user_name": "enemy-two",
+            "total_rounds_played": 0,
+            "attackerteam": 2,
+            "userteam": 3,
+        },
+        {
+            "attacker_name": "enemy",
+            "user_name": "bravo",
+            "total_rounds_played": 1,
+            "attackerteam": 3,
+            "userteam": 2,
+        },
+    ])
+    begin_defuse = pd.DataFrame([
+        {"user_name": "alpha", "tick": 100, "total_rounds_played": 0},
+        {"user_name": "alpha", "tick": 300, "total_rounds_played": 1},
+    ])
+    defused = pd.DataFrame([
+        {"user_name": "alpha", "tick": 150},
+        {"user_name": "alpha", "tick": 350},
+    ])
+
+    indexes = _build_shared_player_indexes(
+        events=deaths,
+        fire_df=fire,
+        hurt_df=hurt,
+        equip_df=equip,
+        begindefuse_df=begin_defuse,
+        defused_df=defused,
+        round_freeze_end_ticks={1: 1, 2: 200},
+    )
+
+    for player in ("alpha", "bravo"):
+        assert indexes.equip_by_player.get(player, ()) == tuple(
+            build_equip_timeline(player, equip)
+        )
+        assert indexes.fire_by_player.get(player, ()) == tuple(
+            build_fire_index(player, fire)
+        )
+        assert indexes.hurt_by_attacker.get(player, ()) == tuple(
+            build_hurt_index(player, hurt)
+        )
+    assert indexes.defuse_windows_by_player["alpha"] == {
+        1: (100, 150),
+        2: (300, 350),
+    }
+    assert indexes.round_hurt_by_victim["enemy"] == {
+        1: ((20, 12, "m4a1"), (40, 30, "ak47")),
+    }
+    assert indexes.team_kills == {
+        1: {2: {"alpha": 1, "bravo": 1}},
+        2: {3: {"enemy": 1}},
+    }

--- a/backend/tests/test_demo_roster_cache.py
+++ b/backend/tests/test_demo_roster_cache.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from app import demo_parse_isolation, main
+from app import demo_parse_isolation, main, parse_worker
 from app.demo_db import DemoDB
 from app.env_utils import AppConfig
 
@@ -457,3 +457,126 @@ def test_library_multi_parse_normalizes_targets_and_uses_first_success(monkeypat
     composite = save_result.await_args.args[1]
     assert composite["auto_target_player"] == "alpha"
     assert composite["analyzed_target_players"] == ["alpha"]
+
+
+def test_upload_metadata_uses_one_combined_inspection_worker(monkeypatch):
+    expected = {
+        "players": [{"name": "alpha"}],
+        "match_meta": {"map_name": "de_nuke", "total_rounds": 24},
+    }
+    calls = []
+
+    def fake_inspect(dem_path):
+        calls.append(dem_path)
+        return expected
+
+    monkeypatch.setattr(demo_parse_isolation, "inspect_demo_isolated", fake_inspect)
+
+    players, match_meta = asyncio.run(main._safe_upload_demo_meta(Path("match.dem")))
+
+    assert players == expected["players"]
+    assert match_meta == expected["match_meta"]
+    assert calls == ["match.dem"]
+
+
+def test_parse_worker_dispatches_combined_inspection(monkeypatch):
+    expected = {
+        "players": [{"name": "alpha"}],
+        "match_meta": {"map_name": "de_nuke"},
+    }
+    calls = []
+
+    def fake_inspect(dem_path):
+        calls.append(dem_path)
+        return expected
+
+    monkeypatch.setattr(parse_worker, "inspect_demo", fake_inspect)
+
+    assert parse_worker._run({"action": "inspect", "dem_path": "match.dem"}) == expected
+    assert calls == ["match.dem"]
+
+
+def test_index_demo_player_stats_reuses_precomputed_roster(monkeypatch):
+    players = [{"name": "alpha", "team": 2}]
+    worker_calls = []
+
+    def worker_must_not_run(dem_path):
+        worker_calls.append(dem_path)
+        raise AssertionError("roster worker should not run")
+
+    monkeypatch.setattr(
+        demo_parse_isolation,
+        "get_player_list_isolated",
+        worker_must_not_run,
+    )
+    replace_stats = AsyncMock()
+    save_cache = AsyncMock()
+    monkeypatch.setattr(main.demo_db, "replace_demo_player_stats", replace_stats)
+    monkeypatch.setattr(main.demo_db, "save_demo_roster_cache", save_cache)
+
+    result = asyncio.run(
+        main.index_demo_player_stats(
+            7,
+            "match.dem",
+            precomputed_players=players,
+        )
+    )
+
+    assert worker_calls == []
+    assert result["players"] == players
+    replace_stats.assert_awaited_once_with(7, "match.dem", players)
+    assert save_cache.await_args.kwargs["row_count"] == 1
+
+
+def test_batch_ingest_bounds_inspection_concurrency_and_reuses_rosters(
+    monkeypatch,
+    tmp_path,
+):
+    rows = []
+    for demo_id in (1, 2, 3):
+        demo_path = tmp_path / f"match-{demo_id}.dem"
+        demo_path.write_bytes(b"demo")
+        rows.append({
+            "id": demo_id,
+            "path": str(demo_path),
+            "filename": demo_path.name,
+            "status": "pending",
+        })
+
+    active = 0
+    max_active = 0
+
+    async def fake_inspect(dem_path):
+        nonlocal active, max_active
+        active += 1
+        max_active = max(max_active, active)
+        await asyncio.sleep(0.01)
+        active -= 1
+        return ([{"name": dem_path.stem}], {"map_name": "de_test"})
+
+    monkeypatch.setattr(main, "_demo_inspect_concurrency", lambda: 2)
+    monkeypatch.setattr(main, "_inspect_demo_meta", fake_inspect)
+    monkeypatch.setattr(
+        main.demo_db,
+        "get_demo_list_items",
+        AsyncMock(return_value=rows),
+    )
+    monkeypatch.setattr(main.demo_db, "update_lightweight_meta", AsyncMock())
+    monkeypatch.setattr(main.demo_db, "update_status", AsyncMock())
+    index_stats = AsyncMock(return_value={"indexed": True, "error": None})
+    monkeypatch.setattr(main, "index_demo_player_stats", index_stats)
+    notify = AsyncMock()
+    monkeypatch.setattr(main, "demo_library_hub", SimpleNamespace(notify=notify))
+
+    response = asyncio.run(
+        main.batch_ingest_demos(main.BatchIngestBody(demo_ids=[1, 2, 3]))
+    )
+
+    assert response == {"ingested": 3, "failed": []}
+    assert max_active == 2
+    assert [call.args[0] for call in index_stats.await_args_list] == [1, 2, 3]
+    assert [
+        call.kwargs["precomputed_players"][0]["name"]
+        for call in index_stats.await_args_list
+    ] == ["match-1", "match-2", "match-3"]
+    notify.assert_awaited_once_with("enqueue")

--- a/backend/tests/test_player_team_fallback.py
+++ b/backend/tests/test_player_team_fallback.py
@@ -21,6 +21,7 @@ from app.parser.player_roster import (
 from app.parser.round_economy import (
     build_group_side_by_round,
     build_round_economy_shared,
+    extract_player_team_maps,
     extract_target_team_map,
 )
 from app.parser.spatial_analysis import parse_spatial_snapshots
@@ -104,6 +105,32 @@ def test_round_economy_recovers_all_players_without_an_extra_parse():
     )
     assert economy == {1: {2: 1000, 3: 2000}, 2: {2: 4000, 3: 3000}}
     assert extract_target_team_map(ticks_df, tick_to_round, "alpha") == {1: 2, 2: 3}
+
+
+def test_player_team_maps_build_all_targets_with_alive_preference():
+    ticks_df = pd.DataFrame([
+        {"tick": 100, "name": "alpha", "team_num": 3, "is_alive": False},
+        {"tick": 100, "name": "alpha", "team_num": 2, "is_alive": True},
+        {"tick": 100, "name": "bravo", "team_num": 3, "is_alive": False},
+        {"tick": 100, "name": "charlie", "team_num": float("nan"), "is_alive": True},
+        {"tick": 100, "name": "charlie", "team_num": 2, "is_alive": True},
+        {"tick": 200, "name": "alpha", "team_num": 3, "is_alive": False},
+        {"tick": 200, "name": "bravo", "team_num": 2, "is_alive": True},
+        {"tick": 200, "name": "ignored", "team_num": 3, "is_alive": True},
+    ])
+
+    result = extract_player_team_maps(
+        ticks_df,
+        {100: 1, 200: 2},
+        target_players=["Alpha", "bravo", "charlie", "missing"],
+    )
+
+    assert result == {
+        "alpha": {1: 2, 2: 3},
+        "bravo": {1: 3, 2: 2},
+        "charlie": {},
+        "missing": {},
+    }
 
 
 def test_round_economy_retries_missing_requested_ticks():


### PR DESCRIPTION
## 改动内容

这次改动继续收敛 Demo 解析链路中的重复工作，主要包含三部分：

- 新增统一的 `inspect` 隔离 worker，在同一个 parser 实例中复用 header、比赛开始事件、死亡事件、回合结束事件和 player info，同时返回玩家名单与比赛摘要。
- 多文件上传与批量入库改为有界并发检查，默认并发数为 2（可通过 `CS2_INSIGHT_DEMO_INSPECT_CONCURRENCY` 配置，限制在 1～4），并直接复用检查结果写入 roster，避免再次启动名单解析 worker。
- 10 玩家分析一次性建立装备、开火、伤害、拆包、回合阵营、队友伤害/击杀等公共索引；轨迹快照从逐行 `iterrows + Series` 构造改为稳定排序后的单次 tuple 遍历。

## 背景

此前多玩家分析虽然已经共享原始事件解析，但部分派生索引仍按玩家重复扫描 DataFrame；上传和入库时，玩家名单与比赛摘要也会分别启动隔离 worker、重复读取同一个 Demo。

这会让全队 10 玩家分析以及批量导入场景承担较多重复的 Python 遍历、进程启动和磁盘读取成本。

## 性能结果

使用两份真实 FACEIT Demo，对全部 10 名玩家进行分析：

- 较长 Demo：`7.314s → 4.51～5.29s`，约 `1.38～1.62×`
- 较短 Demo：`3.976s → 2.28～2.31s`，约 `1.72～1.74×`
- 同口径 cProfile：`15.416s → 6.853s`，约 `2.25×`
- Python 函数调用量：约 `2980 万 → 470 万`，减少约 84%
- 名单与摘要联合检查：约 `1.49～1.72×`
- 两 Demo 有界并发检查：`4.223s → 3.186s`，约 `1.33×`

优化后剩余耗时主要集中在 demoparser 的原生 `parse_events / parse_ticks / parse_event`，逐玩家 Python 重复遍历已经不再是主要瓶颈。

## 数据一致性

两份 Demo 的 10 玩家结果在归一化随机 clip ID 后，SHA-256 与改动前完全一致：

- `a71c982526720649c9254931e654a4033d0d28ccfba756cc61413bdcb8a0e401`
- `de2f3d87104c6650717c667aa78b79439c753caf43f629f5230d5a7d1579920e`

归一化结果大小仍分别为 `1,503,716` 和 `733,797` 字节；玩家名单与比赛摘要也逐项一致。

## 验证

- 56 个解析链路定向测试通过
- 排除未修改的 OBS fade 测试后：`181 passed`
- 完整测试：`186 passed, 2 failed`；两个失败均为与本 PR 无关、单独运行同样失败的 OBS fade 配置断言
- `compileall` 通过
- `git diff --check` 通过
