### PR TITLE
Fix demo voice isolation by POV SteamID

### DIFF
--- a/backend/app/obs_director.py
+++ b/backend/app/obs_director.py
@@ -53,6 +53,10 @@ from .gsi_ready import (
     wait_gsi_payload_after,
 )
 from .pov_constants import POV_CORE_FORCED_COMMANDS, pov_tail_commands
+from .recording.platform_utils import (
+    normalize_voice_filter,
+    select_voice_listen_mask,
+)
 from .win_cs2_console import ensure_cs2_foreground, find_cs2_hwnd, inject_console_sequence, send_cs2_space_taps
 
 logger = logging.getLogger(__name__)
@@ -1781,7 +1785,8 @@ class RecordingWarmupExtras:
     third_person_camera: bool = False
     # Demo 观战闪光弹亮度；None 表示不注入。POV HUD 录制时由 pov_constants 强制 1.0
     spectator_flashbang_opacity: Optional[float] = None
-    # "mute"=全部静音, "open"=所有玩家, "team"=只听主角队伍, "enemy"=只听对方队伍, "off"=不注入
+    # "mute"=全部静音, "open"=所有玩家, "team"=当前 POV 队伍,
+    # "enemy"=当前 POV 对方队伍, "off"=不管理语音
     voice_filter: str = "mute"
     # Demo 底部时间轴 / 回放控制条：社区常用需先 sv_cheats 1 再 demoui false
     hide_demo_playback_ui: bool = True
@@ -1855,6 +1860,12 @@ def _parse_record_inject_console_lines(raw: str) -> tuple[str, ...]:
 # 依赖"已第一人称观战某玩家"才生效的 cvar：warmup 阶段注入无效，
 # 必须在每片段 spec_player 锁定后再注入一次（参考 tv_listen_voice_indices 处理）。
 _POST_SPEC_CVAR_NAMES: frozenset[str] = frozenset({"cl_demo_predict"})
+_VOICE_CVAR_NAMES: frozenset[str] = frozenset({
+    "voice_modenable",
+    "snd_voipvolume",
+    "tv_listen_voice_indices",
+    "tv_listen_voice_indices_h",
+})
 
 
 def _filter_post_spec_console_lines(lines) -> list[str]:
@@ -1868,6 +1879,64 @@ def _filter_post_spec_console_lines(lines) -> list[str]:
         if cvar in _POST_SPEC_CVAR_NAMES:
             out.append(s)
     return out
+
+
+def _without_voice_console_lines(lines) -> list[str]:
+    """Remove stale client-generated voice commands; backend policy is authoritative."""
+    out: list[str] = []
+    for line in lines or ():
+        value = str(line).strip()
+        if not value:
+            continue
+        if value.split()[0].lower() not in _VOICE_CVAR_NAMES:
+            out.append(value)
+    return out
+
+
+def _voice_filter_warmup_console_lines(voice_filter) -> list[str]:
+    """Return the authoritative final voice state for the selected mode."""
+    mode = normalize_voice_filter(voice_filter)
+    if mode == "off":
+        return []
+    if mode == "open":
+        return [
+            "voice_modenable 1",
+            "snd_voipvolume 1",
+            "tv_listen_voice_indices -1",
+            "tv_listen_voice_indices_h -1",
+        ]
+
+    # Restricted modes start silent. Per-segment team/enemy masks are applied only
+    # after the POV SteamID has been selected and verified.
+    lines = [
+        "tv_listen_voice_indices 0",
+        "tv_listen_voice_indices_h 0",
+    ]
+    if mode in ("team", "enemy"):
+        lines.extend(("voice_modenable 1", "snd_voipvolume 1"))
+    else:
+        lines.extend(("voice_modenable 0", "snd_voipvolume 0"))
+    return lines
+
+
+def _apply_voice_filter_to_plan(plan, voice_filter) -> str:
+    """Resolve each final segment mask, muting when roster identity is incomplete."""
+    mode = normalize_voice_filter(voice_filter)
+    for segment in plan.segments:
+        selected = select_voice_listen_mask(
+            mode,
+            segment.voice_listen_mask or 0,
+            segment.voice_listen_mask_enemy or 0,
+        )
+        if mode in ("team", "enemy") and selected == 0:
+            warning = (
+                f"segment {segment.segment_index}: {mode} voice roster unavailable for "
+                f"POV SteamID {segment.target_steamid64 or '(missing)'}; muted fail-closed"
+            )
+            if warning not in plan.warnings:
+                plan.warnings.append(warning)
+        segment.voice_listen_mask = selected
+    return mode
 
 
 class OBSDirector:
@@ -3299,10 +3368,11 @@ class OBSDirector:
         我们 SendInput 投到默认 F10 / ``~`` 失效。
         """
         if w.console_cmds:
-            cmds = [str(x).strip() for x in w.console_cmds if str(x).strip()]
-            return self._append_config_warmup_console_lines(
+            cmds = _without_voice_console_lines(w.console_cmds)
+            lines = self._append_config_warmup_console_lines(
                 [*_RECORDING_KEYBIND_RESET_LINES, *cmds]
             )
+            return [*lines, *_voice_filter_warmup_console_lines(w.voice_filter)]
         lines: list[str] = []
         lines.extend(_RECORDING_KEYBIND_RESET_LINES)
         if w.cl_draw_only_deathnotices:
@@ -3348,24 +3418,13 @@ class OBSDirector:
                 _fb_f = 0.6
             _fb_f = max(0.2, min(1.0, _fb_f))
             lines.append(f"r_spectator_flashbang_opacity {_fb_f:g}")
-        _vf = getattr(w, "voice_filter", "mute")
-        if _vf in ("mute", "all"):  # "all" 为旧值向后兼容
-            lines.append("snd_voipvolume 0")
-        elif _vf == "open":
-            lines.append("snd_voipvolume 1")
-            lines.append("tv_listen_voice_indices -1")
-        elif _vf == "off":
-            pass  # 不注入任何语音指令
-        else:  # "team" or "enemy" — 先打开全员基线，per-segment 再收窄到掩码
-            # all_players 为空时以"全部可听"降级，而不是静音
-            lines.append("snd_voipvolume 1")
-            lines.append("tv_listen_voice_indices -1")
         if w.hide_grenade_trajectory_pip:
             lines.append("sv_grenade_trajectory 0")
             lines.append("sv_grenade_trajectory_prac_pipreview 0")
             lines.append("cl_grenadepreview 0")
             lines.append("sv_grenade_trajectory_time_spectator 0")
-        return self._append_config_warmup_console_lines(lines)
+        lines = self._append_config_warmup_console_lines(lines)
+        return [*lines, *_voice_filter_warmup_console_lines(w.voice_filter)]
 
     async def execute_plan_queue(
         self,
@@ -3590,6 +3649,10 @@ class OBSDirector:
                 # KP_5/KP_6 are bound here so that demo_pause_silent/demo_resume_silent
                 # can send a keypress instead of opening the console during recording.
                 _V3_DEMO_KEY_BINDINGS = ["bind KP_5 demo_pause", "bind KP_6 demo_resume"]
+                _voice_mode = normalize_voice_filter(
+                    getattr(warmup, "voice_filter", "mute") if warmup else "mute"
+                )
+                _warmup_inject_ok = False
                 if warmup is not None:
                     warmup_cmds = self._recording_warmup_console_lines(warmup)
                     warmup_cmds = [*warmup_cmds, *_V3_DEMO_KEY_BINDINGS]
@@ -3609,15 +3672,50 @@ class OBSDirector:
                             for _cmd in pov_cmds:
                                 logger.info("[RecordingV3][POV] inject command: %s", _cmd)
                         try:
-                            await asyncio.to_thread(inject_console_sequence, warmup_cmds)
+                            _warmup_inject_ok = bool(
+                                await asyncio.to_thread(inject_console_sequence, warmup_cmds)
+                            )
+                            if not _warmup_inject_ok:
+                                logger.warning("[RecordingV3] warmup console injection returned false")
                         except Exception as _wce:
                             logger.warning("[RecordingV3] warmup console inject failed: %s", _wce)
                 else:
-                    # No warmup object — still inject the demo control key bindings.
+                    # No warmup object means the safe default: mute via both mask halves.
                     try:
-                        await asyncio.to_thread(inject_console_sequence, list(_V3_DEMO_KEY_BINDINGS))
+                        _warmup_inject_ok = bool(await asyncio.to_thread(
+                            inject_console_sequence,
+                            [
+                                *_V3_DEMO_KEY_BINDINGS,
+                                *_voice_filter_warmup_console_lines("mute"),
+                            ],
+                        ))
+                        if not _warmup_inject_ok:
+                            logger.warning("[RecordingV3] default mute warmup injection returned false")
                     except Exception as _wce:
                         logger.warning("[RecordingV3] demo key bindings inject failed: %s", _wce)
+
+                if _voice_mode in ("mute", "team", "enemy") and not _warmup_inject_ok:
+                    error = "voice isolation warmup injection failed; recording aborted fail-closed"
+                    logger.error("[RecordingV3] %s", error)
+                    for dto in demo_requests:
+                        all_results.append({
+                            "request_id": dto.request_id,
+                            "success": False,
+                            "error": error,
+                            "segment_results": [],
+                            "warnings": [],
+                        })
+                    await self._run_cleanup_step(
+                        "CS2 shutdown after voice isolation failure",
+                        self._kill_cs2,
+                        timeout=30.0,
+                    )
+                    await self._run_cleanup_step(
+                        "CS2 artifact cleanup after voice isolation failure",
+                        self._cleanup_cs2_artifacts,
+                        timeout=8.0,
+                    )
+                    continue
 
                 # ── Connect OBS right before recording (fresh connection avoids dead recv thread)
                 if obs_client.is_connected():
@@ -3681,14 +3779,9 @@ class OBSDirector:
                         logger.info("[RecordingV3] using pre-built plan: request_id=%s type=%s",
                                     dto.request_id, dto.request_type.value)
 
-                    # ── voice_filter: patch segment masks before execution ────────
-                    _vf = getattr(warmup, "voice_filter", "mute") if warmup else "mute"
-                    if _vf in ("off", "open", "mute", "all"):
-                        for _seg in plan.segments:
-                            _seg.voice_listen_mask = None
-                    elif _vf == "enemy":
-                        for _seg in plan.segments:
-                            _seg.voice_listen_mask = _seg.voice_listen_mask_enemy
+                    # Resolve every segment explicitly. Missing roster data is mask 0;
+                    # only an explicit "off" leaves voice state unmanaged (None).
+                    _apply_voice_filter_to_plan(plan, _voice_mode)
 
                     logger.info("[RecordingV3] execute plan: %d active segments", len(plan.segments))
                     _pre_execute_wall = time.time()

--- a/backend/app/recording/executor/recording_executor.py
+++ b/backend/app/recording/executor/recording_executor.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass, field
 from typing import Optional
 
 from ..models import RecordingPlan, RecordingSegment, SourceType, Perspective
+from ..platform_utils import voice_listen_mask_console_commands
 from .obs_client import OBSClient
 from .obs_recording_controller import OBSRecordingController, OBSControlError
 from .obs_fade_controller import OBSFadeController
@@ -17,6 +18,21 @@ from .spec_controller import spec_by_slot, spec_player
 from .gsi_verifier import verify_spec_target
 
 logger = logging.getLogger(__name__)
+
+
+class VoiceIsolationError(RuntimeError):
+    """A managed voice mask could not be applied before recording a segment."""
+
+
+async def _inject_voice_listen_mask(mask: int) -> None:
+    commands = voice_listen_mask_console_commands(mask)
+    try:
+        ok = await asyncio.to_thread(inject_console_sequence, commands)
+    except Exception as exc:
+        raise VoiceIsolationError(f"voice mask injection raised: {exc}") from exc
+    if ok is not True:
+        raise VoiceIsolationError("voice mask injection returned false")
+
 
 def _kb_bus(segment=None):
     """Return (bus, keyboard_tick_offset, kill_fx_tick_offset).
@@ -655,6 +671,7 @@ class RecordingExecutor:
                 # voice/post-spec console injections also consume demo ticks.
                 prepare_t0 = time.monotonic()
                 spec_elapsed = 0.0
+                spec_ok = None
                 if segment.target_steamid64 or segment.target_player_name:
                     spec_t0 = time.monotonic()
                     spec_ok = await _spec_by_slot_with_retry(
@@ -665,18 +682,6 @@ class RecordingExecutor:
                         segment_index=segment.segment_index,
                     )
                     spec_elapsed = time.monotonic() - spec_t0
-
-                    if spec_ok is not False and segment.voice_listen_mask is not None:
-                        mask_val = segment.voice_listen_mask
-                        try:
-                            await asyncio.to_thread(
-                                inject_console_sequence,
-                                ["tv_listen_voice_indices -1", f"tv_listen_voice_indices {mask_val}"],
-                            )
-                        except Exception as _e:
-                            logger.warning(
-                                "[RecordingV3] tv_listen_voice_indices inject failed: %s", _e
-                            )
 
                     if spec_ok is not False and self._post_spec_console_lines:
                         try:
@@ -719,6 +724,9 @@ class RecordingExecutor:
                         result.success = any(r.status == "ok" for r in result.segment_results)
                         result.warnings.extend(plan.warnings)
                         return result
+
+                if segment.voice_listen_mask is not None:
+                    await _inject_voice_listen_mask(segment.voice_listen_mask)
 
                 # ── 3. Sync to start_tick, then pause ───────────────────────
                 # spec_player / GSI-verify run while the demo plays in the prepare window.
@@ -789,17 +797,8 @@ class RecordingExecutor:
                             result.success = any(r.status == "ok" for r in result.segment_results)
                             result.warnings.extend(plan.warnings)
                             return result
-                        if spec_ok is not False and segment.voice_listen_mask is not None:
-                            mask_val = segment.voice_listen_mask
-                            try:
-                                await asyncio.to_thread(
-                                    inject_console_sequence,
-                                    ["tv_listen_voice_indices -1", f"tv_listen_voice_indices {mask_val}"],
-                                )
-                            except Exception as _e:
-                                logger.warning(
-                                    "[RecordingV3] tv_listen_voice_indices inject failed: %s", _e
-                                )
+                    if segment.voice_listen_mask is not None:
+                        await _inject_voice_listen_mask(segment.voice_listen_mask)
 
                 logger.info(
                     "[RecordingV3] spec_elapsed=%.2fs prepare_elapsed=%.2fs "
@@ -1003,6 +1002,36 @@ class RecordingExecutor:
                 # confirmed paused. If it returned "fallback_stopped", the next
                 # segment loop iteration will see self._obs_force_stopped=True and break.
                 # Either way, gototick/spec_player console calls are safe from here.
+
+            except VoiceIsolationError as e:
+                logger.error(
+                    "Segment %d voice isolation failed: %s",
+                    segment.segment_index,
+                    e,
+                )
+                try:
+                    await demo_pause()
+                except Exception:
+                    pass
+                result.segment_results.append(SegmentResult(
+                    segment_index=segment.segment_index,
+                    status="voice_filter_failed",
+                    start_tick=segment.start_tick,
+                    end_tick=segment.end_tick,
+                    perspective=segment.perspective,
+                    error=str(e),
+                ))
+                result.error = f"voice isolation failed before recording: {e}"
+                if obs_recording_started:
+                    try:
+                        final_output_path = await self._ctrl.stop_record_safe()
+                    except Exception:
+                        pass
+                    obs_recording_started = False
+                result.output_path = final_output_path
+                result.success = False
+                result.warnings.extend(plan.warnings)
+                return result
 
             except OBSControlError as e:
                 logger.error("Segment %d OBS control error: %s", segment.segment_index, e)

--- a/backend/app/recording/platform_utils.py
+++ b/backend/app/recording/platform_utils.py
@@ -2,7 +2,10 @@
 from __future__ import annotations
 
 import re
-from typing import Optional
+
+
+VOICE_LISTEN_MASK_ALL = (1 << 64) - 1
+_VOICE_FILTER_MODES = frozenset({"off", "open", "team", "enemy", "mute"})
 
 
 def infer_demo_source(filename: str, server_name: str = "") -> str:
@@ -61,71 +64,139 @@ def compute_voice_listen_mask(
     all_players: list[dict],
     target_steamid64: str,
     slot_offset: int,
-) -> Optional[int]:
+) -> int:
     """计算 ``tv_listen_voice_indices`` 位掩码，只听目标玩家队伍的语音。
 
     掩码规则：slot 1-based → bit index = slot-1 → bit value = 1<<(slot-1)。
     所有属于目标玩家队伍的 spec_slot（加 offset 后）对应的位置 1。
 
-    返回 None 表示数据不足（无法确定队伍），调用方应回落到 -1（全员）。
+    SteamID 是唯一身份真源；不会按昵称回退。返回 0 表示数据不足，调用方必须
+    fail-closed（静音），不能回落到 -1（全员）。
     """
-    if not all_players or not target_steamid64:
-        return None
-
-    # 找目标玩家的 team_num
-    target_team: Optional[int] = None
-    for p in all_players:
-        if p.get("steamid64") == target_steamid64 and p.get("team_num") in (2, 3):
-            target_team = p["team_num"]
-            break
-
-    if target_team is None:
-        return None
-
-    # 对目标玩家队伍中所有有效 slot 的玩家设置对应 bit
-    mask = 0
-    for p in all_players:
-        if p.get("team_num") != target_team:
-            continue
-        slot = p.get("spec_slot")
-        if slot is None:
-            continue
-        actual = int(slot) + slot_offset
-        if 1 <= actual <= 64:
-            mask |= 1 << (actual - 1)
-
-    return mask if mask != 0 else None
+    target_team = _resolve_target_team(all_players, target_steamid64)
+    return _compute_team_mask(all_players, target_team, slot_offset)
 
 
 def compute_voice_listen_mask_enemy(
     all_players: list[dict],
     target_steamid64: str,
     slot_offset: int,
-) -> Optional[int]:
+) -> int:
     """计算 ``tv_listen_voice_indices`` 位掩码，只听目标玩家对方队伍的语音。"""
-    if not all_players or not target_steamid64:
-        return None
-
-    target_team: Optional[int] = None
-    for p in all_players:
-        if p.get("steamid64") == target_steamid64 and p.get("team_num") in (2, 3):
-            target_team = p["team_num"]
-            break
-
-    if target_team is None:
-        return None
-
+    target_team = _resolve_target_team(all_players, target_steamid64)
+    if target_team not in (2, 3):
+        return 0
     enemy_team = 3 if target_team == 2 else 2
+    return _compute_team_mask(all_players, enemy_team, slot_offset)
+
+
+def _steamid_key(value) -> str:
+    """Return the exact comparable SteamID representation used by demo rosters."""
+    return str(value).strip() if value is not None else ""
+
+
+def _valid_team_num(value) -> int:
+    try:
+        team_num = int(value)
+    except (TypeError, ValueError, OverflowError):
+        return 0
+    return team_num if team_num in (2, 3) else 0
+
+
+def _resolve_target_team(all_players: list[dict], target_steamid64: str) -> int:
+    target_key = _steamid_key(target_steamid64)
+    if not all_players or not target_key:
+        return 0
+
+    teams = {
+        _valid_team_num(player.get("team_num"))
+        for player in all_players
+        if isinstance(player, dict)
+        and _steamid_key(player.get("steamid64")) == target_key
+    }
+    teams.discard(0)
+    # Conflicting roster rows are unsafe to guess through.
+    return next(iter(teams)) if len(teams) == 1 else 0
+
+
+def _compute_team_mask(all_players: list[dict], team_num: int, slot_offset: int) -> int:
+    if team_num not in (2, 3):
+        return 0
 
     mask = 0
-    for p in all_players:
-        if p.get("team_num") != enemy_team:
+    for player in all_players or []:
+        if not isinstance(player, dict):
             continue
-        slot = p.get("spec_slot")
+        # Unidentified roster rows are never allowed into a team voice mask.
+        if not _steamid_key(player.get("steamid64")):
+            continue
+        if _valid_team_num(player.get("team_num")) != team_num:
+            continue
+        slot = player.get("spec_slot")
         if slot is None:
             continue
-        actual = int(slot) + slot_offset
+        try:
+            actual = int(slot) + int(slot_offset)
+        except (TypeError, ValueError, OverflowError):
+            continue
         if 1 <= actual <= 64:
             mask |= 1 << (actual - 1)
+    return mask
 
-    return mask if mask != 0 else None
+
+def normalize_voice_filter(value) -> str:
+    """Normalize persisted/legacy values; unknown modes default to mute."""
+    mode = str(value or "mute").strip().lower()
+    if mode == "all":  # historical value meant mute-all
+        return "mute"
+    return mode if mode in _VOICE_FILTER_MODES else "mute"
+
+
+def select_voice_listen_mask(
+    voice_filter,
+    team_mask: int,
+    enemy_mask: int,
+) -> "int | None":
+    """Resolve the final per-segment mask. ``None`` is reserved for explicit off."""
+    mode = normalize_voice_filter(voice_filter)
+    if mode == "off":
+        return None
+    if mode == "open":
+        return VOICE_LISTEN_MASK_ALL
+    if mode == "team":
+        return int(team_mask or 0)
+    if mode == "enemy":
+        return int(enemy_mask or 0)
+    return 0
+
+
+def split_voice_listen_mask(mask: int) -> tuple[int, int]:
+    """Split a 64-bit mask into the signed int32 values accepted by CS2 cvars."""
+    if isinstance(mask, bool) or not isinstance(mask, int):
+        raise ValueError("voice listen mask must be an integer")
+    if mask < 0 or mask > VOICE_LISTEN_MASK_ALL:
+        raise ValueError("voice listen mask must fit in 64 bits")
+
+    def _signed_int32(word: int) -> int:
+        return word if word < (1 << 31) else word - (1 << 32)
+
+    low = _signed_int32(mask & 0xFFFFFFFF)
+    high = _signed_int32((mask >> 32) & 0xFFFFFFFF)
+    return low, high
+
+
+def voice_listen_mask_console_commands(mask: int) -> list[str]:
+    """Build a fail-closed low/high mask update for one POV segment."""
+    low, high = split_voice_listen_mask(mask)
+    commands = [
+        "tv_listen_voice_indices 0",
+        "tv_listen_voice_indices_h 0",
+    ]
+    if mask:
+        commands.extend(
+            (
+                f"tv_listen_voice_indices {low}",
+                f"tv_listen_voice_indices_h {high}",
+            )
+        )
+    return commands

--- a/backend/app/recording/postprocess/segment_postprocessor.py
+++ b/backend/app/recording/postprocess/segment_postprocessor.py
@@ -1,5 +1,10 @@
 from ..models import RecordingSegment, SourceType, Perspective, RequestType
 from ..normalizer import NormalizedRequest
+from ..platform_utils import (
+    compute_voice_listen_mask,
+    compute_voice_listen_mask_enemy,
+    platform_slot_offset,
+)
 from .final_round_guard import apply_final_round_guard
 
 
@@ -16,6 +21,10 @@ def postprocess_segments(
     warnings: list[str] = list(extra_warnings) if extra_warnings else []
 
     processed: list[RecordingSegment] = []
+    voice_slot_offset = platform_slot_offset(
+        req.demo.demo_filename,
+        req.demo.server_name,
+    )
 
     for segment in segments:
         # Step 1: Clamp to demo bounds
@@ -29,6 +38,22 @@ def postprocess_segments(
         # Step 2: Apply FinalRoundGuard (returns tuple[segment, warnings])
         segment, guard_warnings = apply_final_round_guard(segment, req)
         warnings.extend(guard_warnings)
+
+        # Voice identity follows the actual POV target of this final segment.
+        # This deliberately overwrites planner-provided masks, because victim/killer
+        # interleaving can switch teams within one request.
+        segment = segment.model_copy(update={
+            "voice_listen_mask": compute_voice_listen_mask(
+                req.demo.all_players,
+                segment.target_steamid64,
+                voice_slot_offset,
+            ),
+            "voice_listen_mask_enemy": compute_voice_listen_mask_enemy(
+                req.demo.all_players,
+                segment.target_steamid64,
+                voice_slot_offset,
+            ),
+        })
 
         # Step 3: Warn when victim segment lacks spec_slot (executor falls back to spec_player by name).
         if (

--- a/backend/tests/test_voice_isolation.py
+++ b/backend/tests/test_voice_isolation.py
@@ -1,0 +1,196 @@
+import asyncio
+
+import pytest
+
+from app.recording.executor import recording_executor as executor_module
+from app.recording.executor.recording_executor import (
+    VoiceIsolationError,
+    _inject_voice_listen_mask,
+)
+from app.recording.models import (
+    DemoContext,
+    EventInfo,
+    EventType,
+    Perspective,
+    RecordingOptions,
+    RecordingRequestDTO,
+    RequestType,
+    SourceType,
+    TargetPlayer,
+)
+from app.recording.plan_builder import build_plan
+from app.recording.platform_utils import (
+    VOICE_LISTEN_MASK_ALL,
+    compute_voice_listen_mask,
+    compute_voice_listen_mask_enemy,
+    select_voice_listen_mask,
+    split_voice_listen_mask,
+    voice_listen_mask_console_commands,
+)
+
+
+def _roster() -> list[dict]:
+    # Names are deliberately non-unique: only SteamID may decide voice identity.
+    return [
+        {
+            "name": "duplicate",
+            "steamid64": str(100 + slot),
+            "spec_slot": slot,
+            "team_num": 3,
+        }
+        for slot in range(1, 6)
+    ] + [
+        {
+            "name": "duplicate",
+            "steamid64": str(200 + slot),
+            "spec_slot": slot,
+            "team_num": 2,
+        }
+        for slot in range(6, 11)
+    ]
+
+
+def _highlight_request(*, interleave: bool) -> RecordingRequestDTO:
+    killer = TargetPlayer(name="duplicate", steamid64="206", spec_slot=6)
+    victim = TargetPlayer(name="duplicate", steamid64="101", spec_slot=1)
+    event = EventInfo(
+        event_type=EventType.kill,
+        tick=1_000,
+        round=1,
+        killer=killer,
+        victim=victim,
+        target_player=killer,
+        perspective=Perspective.killer,
+    )
+    return RecordingRequestDTO(
+        request_id=f"voice-{interleave}",
+        request_type=RequestType.highlight,
+        source_type=SourceType.kill,
+        demo=DemoContext(
+            demo_path="match.dem",
+            demo_filename="match.dem",
+            map_name="de_mirage",
+            tick_rate=64,
+            first_tick=0,
+            demo_end_tick=10_000,
+            final_round=2,
+            final_round_start_tick=8_000,
+            final_round_end_tick=9_000,
+            all_players=_roster(),
+        ),
+        target_player=killer,
+        events=[event],
+        options=RecordingOptions(
+            enable_victim_pov=True,
+            interleave_pov_pairs=interleave,
+        ),
+    )
+
+
+@pytest.mark.parametrize("interleave", [False, True])
+def test_final_segments_follow_each_pov_steamid(interleave):
+    plan = build_plan(_highlight_request(interleave=interleave))
+
+    assert [segment.target_steamid64 for segment in plan.segments] == ["206", "101"]
+    assert [segment.voice_listen_mask for segment in plan.segments] == [992, 31]
+    assert [segment.voice_listen_mask_enemy for segment in plan.segments] == [31, 992]
+
+
+def test_voice_mask_uses_exact_steamid_and_skips_unidentified_rows():
+    roster = _roster()
+    roster.append({"name": "duplicate", "steamid64": "", "spec_slot": 11, "team_num": 2})
+
+    assert compute_voice_listen_mask(roster, 206, 0) == 992
+    assert compute_voice_listen_mask_enemy(roster, "206", 0) == 31
+    assert compute_voice_listen_mask(roster, "missing", 0) == 0
+
+
+def test_conflicting_target_team_fails_closed():
+    roster = _roster()
+    roster.append({"name": "duplicate", "steamid64": "206", "spec_slot": 12, "team_num": 3})
+
+    assert compute_voice_listen_mask(roster, "206", 0) == 0
+    assert compute_voice_listen_mask_enemy(roster, "206", 0) == 0
+
+
+def test_platform_offset_and_invalid_slots_stay_in_64_bits():
+    roster = [
+        {"steamid64": "target", "spec_slot": 32, "team_num": 2},
+        {"steamid64": "overflow", "spec_slot": 64, "team_num": 2},
+    ]
+
+    assert compute_voice_listen_mask(roster, "target", 1) == 1 << 32
+
+
+@pytest.mark.parametrize(
+    ("mask", "expected"),
+    [
+        (0, (0, 0)),
+        (1 << 31, (-2_147_483_648, 0)),
+        (1 << 32, (0, 1)),
+        (1 << 63, (0, -2_147_483_648)),
+        (VOICE_LISTEN_MASK_ALL, (-1, -1)),
+    ],
+)
+def test_split_voice_mask_covers_low_and_high_words(mask, expected):
+    assert split_voice_listen_mask(mask) == expected
+
+
+def test_restrictive_mask_commands_reset_both_halves_without_opening_all():
+    commands = voice_listen_mask_console_commands((1 << 32) | 1)
+
+    assert commands == [
+        "tv_listen_voice_indices 0",
+        "tv_listen_voice_indices_h 0",
+        "tv_listen_voice_indices 1",
+        "tv_listen_voice_indices_h 1",
+    ]
+    assert all(not command.endswith(" -1") for command in commands)
+
+
+def test_zero_mask_still_clears_both_halves():
+    assert voice_listen_mask_console_commands(0) == [
+        "tv_listen_voice_indices 0",
+        "tv_listen_voice_indices_h 0",
+    ]
+
+
+def test_voice_filter_modes_are_explicit_and_fail_closed():
+    assert select_voice_listen_mask("off", 3, 12) is None
+    assert select_voice_listen_mask("open", 3, 12) == VOICE_LISTEN_MASK_ALL
+    assert select_voice_listen_mask("team", 3, 12) == 3
+    assert select_voice_listen_mask("enemy", 3, 12) == 12
+    assert select_voice_listen_mask("team", 0, 12) == 0
+    assert select_voice_listen_mask("mute", 3, 12) == 0
+    assert select_voice_listen_mask("all", 3, 12) == 0
+    assert select_voice_listen_mask("unexpected", 3, 12) == 0
+
+
+def test_executor_voice_injection_checks_boolean_result(monkeypatch):
+    captured = []
+
+    def inject(commands):
+        captured.append(commands)
+        return True
+
+    monkeypatch.setattr(executor_module, "inject_console_sequence", inject)
+    asyncio.run(_inject_voice_listen_mask(3))
+    assert captured == [[
+        "tv_listen_voice_indices 0",
+        "tv_listen_voice_indices_h 0",
+        "tv_listen_voice_indices 3",
+        "tv_listen_voice_indices_h 0",
+    ]]
+
+    monkeypatch.setattr(executor_module, "inject_console_sequence", lambda _commands: False)
+    with pytest.raises(VoiceIsolationError, match="returned false"):
+        asyncio.run(_inject_voice_listen_mask(3))
+
+
+def test_executor_voice_injection_wraps_exceptions(monkeypatch):
+    def inject(_commands):
+        raise RuntimeError("console unavailable")
+
+    monkeypatch.setattr(executor_module, "inject_console_sequence", inject)
+    with pytest.raises(VoiceIsolationError, match="console unavailable"):
+        asyncio.run(_inject_voice_listen_mask(3))

--- a/backend/tests/test_warmup_console_merge.py
+++ b/backend/tests/test_warmup_console_merge.py
@@ -1,7 +1,14 @@
 """录制预热控制台注入：固定 cvar 已迁出硬编码，仅由 record_inject_console_lines 提供。"""
 
+from types import SimpleNamespace
+
 from app.env_utils import OBSConfig
-from app.obs_director import OBSDirector, RecordingWarmupExtras
+from app.obs_director import (
+    OBSDirector,
+    RecordingWarmupExtras,
+    _apply_voice_filter_to_plan,
+)
+from app.recording.platform_utils import VOICE_LISTEN_MASK_ALL
 
 FIXED_CVARS = (
     "cl_hud_telemetry_frametime_show 0",
@@ -57,3 +64,104 @@ def test_third_person_camera_injects_the_configured_camera_commands():
     ]
     start = lines.index("cam_command 1")
     assert lines[start : start + len(third_person_commands)] == third_person_commands
+
+
+def test_team_and_enemy_warmup_start_fail_closed():
+    director = _director("")
+
+    for mode in ("team", "enemy"):
+        lines = director._recording_warmup_console_lines(
+            RecordingWarmupExtras(voice_filter=mode)
+        )
+        assert lines[-4:] == [
+            "tv_listen_voice_indices 0",
+            "tv_listen_voice_indices_h 0",
+            "voice_modenable 1",
+            "snd_voipvolume 1",
+        ]
+        assert "tv_listen_voice_indices -1" not in lines
+        assert "tv_listen_voice_indices_h -1" not in lines
+
+
+def test_mute_does_not_depend_on_snd_voipvolume():
+    director = _director("")
+    lines = director._recording_warmup_console_lines(
+        RecordingWarmupExtras(voice_filter="mute")
+    )
+
+    assert lines[-4:] == [
+        "tv_listen_voice_indices 0",
+        "tv_listen_voice_indices_h 0",
+        "voice_modenable 0",
+        "snd_voipvolume 0",
+    ]
+
+
+def test_open_sets_both_mask_halves_to_all_players():
+    director = _director("")
+    lines = director._recording_warmup_console_lines(
+        RecordingWarmupExtras(voice_filter="open")
+    )
+
+    assert lines[-4:] == [
+        "voice_modenable 1",
+        "snd_voipvolume 1",
+        "tv_listen_voice_indices -1",
+        "tv_listen_voice_indices_h -1",
+    ]
+
+
+def test_off_leaves_voice_unmanaged():
+    director = _director("")
+    lines = director._recording_warmup_console_lines(
+        RecordingWarmupExtras(voice_filter="off")
+    )
+
+    assert not any(line.split()[0] in {
+        "voice_modenable",
+        "snd_voipvolume",
+        "tv_listen_voice_indices",
+        "tv_listen_voice_indices_h",
+    } for line in lines)
+
+
+def test_stale_client_voice_commands_cannot_override_team_policy():
+    director = _director("tv_listen_voice_indices -1\ntv_listen_voice_indices_h -1")
+    lines = director._recording_warmup_console_lines(RecordingWarmupExtras(
+        voice_filter="team",
+        console_cmds=(
+            "cl_draw_only_deathnotices true",
+            "snd_voipvolume 1",
+            "tv_listen_voice_indices -1",
+            "tv_listen_voice_indices_h -1",
+        ),
+    ))
+
+    assert "cl_draw_only_deathnotices true" in lines
+    assert lines[-4:] == [
+        "tv_listen_voice_indices 0",
+        "tv_listen_voice_indices_h 0",
+        "voice_modenable 1",
+        "snd_voipvolume 1",
+    ]
+
+
+def test_plan_modes_resolve_masks_explicitly():
+    segment = SimpleNamespace(
+        segment_index=0,
+        target_steamid64="76561198000000001",
+        voice_listen_mask=3,
+        voice_listen_mask_enemy=12,
+    )
+    plan = SimpleNamespace(segments=[segment], warnings=[])
+
+    assert _apply_voice_filter_to_plan(plan, "open") == "open"
+    assert segment.voice_listen_mask == VOICE_LISTEN_MASK_ALL
+
+    segment.voice_listen_mask = 0
+    assert _apply_voice_filter_to_plan(plan, "team") == "team"
+    assert segment.voice_listen_mask == 0
+    assert "muted fail-closed" in plan.warnings[-1]
+
+    assert _apply_voice_filter_to_plan(plan, "off") == "off"
+    assert segment.voice_listen_mask is None

--- a/frontend/src/components/RecordWarmupModal.jsx
+++ b/frontend/src/components/RecordWarmupModal.jsx
@@ -59,17 +59,29 @@ export function buildWarmupConsoleCommands(o) {
   }
   const vf = o.voice_filter ?? "mute";
   if (vf === "mute" || vf === "all") {
-    lines.push("snd_voipvolume 0");
+    lines.push(
+      "tv_listen_voice_indices 0",
+      "tv_listen_voice_indices_h 0",
+      "voice_modenable 0",
+      "snd_voipvolume 0",
+    );
   } else if (vf === "open") {
-    lines.push("snd_voipvolume 1");
-    lines.push("tv_listen_voice_indices -1");
+    lines.push(
+      "voice_modenable 1",
+      "snd_voipvolume 1",
+      "tv_listen_voice_indices -1",
+      "tv_listen_voice_indices_h -1",
+    );
   } else if (vf === "off") {
     // 不注入语音指令
   } else {
-    // "team" / "enemy"：先打开全员基线，per-segment 再收窄到掩码
-    // all_players 为空时以"全部可听"降级，而不是静音
-    lines.push("snd_voipvolume 1");
-    lines.push("tv_listen_voice_indices -1");
+    // "team" / "enemy"：先静音，per-segment 按当前 POV SteamID 成功解析后再放行。
+    lines.push(
+      "tv_listen_voice_indices 0",
+      "tv_listen_voice_indices_h 0",
+      "voice_modenable 1",
+      "snd_voipvolume 1",
+    );
   }
   if (o.hide_grenade_trajectory_pip) {
     lines.push("sv_grenade_trajectory 0");

--- a/frontend/src/components/RecordWarmupModal.voice.test.js
+++ b/frontend/src/components/RecordWarmupModal.voice.test.js
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildWarmupConsoleCommands,
+  RECORD_WARMUP_DEFAULT_OPTIONS,
+} from "./RecordWarmupModal.jsx";
+
+
+function voiceCommands(mode) {
+  return buildWarmupConsoleCommands({
+    ...RECORD_WARMUP_DEFAULT_OPTIONS,
+    voice_filter: mode,
+  }).filter((command) => /^(voice_modenable|snd_voipvolume|tv_listen_voice_indices)/.test(command));
+}
+
+
+describe("recording warmup voice commands", () => {
+  it("mutes through voice enable and both mask halves", () => {
+    expect(voiceCommands("mute")).toEqual([
+      "tv_listen_voice_indices 0",
+      "tv_listen_voice_indices_h 0",
+      "voice_modenable 0",
+      "snd_voipvolume 0",
+    ]);
+  });
+
+  it.each(["team", "enemy"])("starts %s mode silent until the POV mask is known", (mode) => {
+    const commands = voiceCommands(mode);
+    expect(commands).toEqual([
+      "tv_listen_voice_indices 0",
+      "tv_listen_voice_indices_h 0",
+      "voice_modenable 1",
+      "snd_voipvolume 1",
+    ]);
+    expect(commands).not.toContain("tv_listen_voice_indices -1");
+    expect(commands).not.toContain("tv_listen_voice_indices_h -1");
+  });
+
+  it("opens both mask halves only for the explicit all-player mode", () => {
+    expect(voiceCommands("open")).toEqual([
+      "voice_modenable 1",
+      "snd_voipvolume 1",
+      "tv_listen_voice_indices -1",
+      "tv_listen_voice_indices_h -1",
+    ]);
+  });
+
+  it("does not manage voice in off mode", () => {
+    expect(voiceCommands("off")).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

- Recompute team/enemy voice masks from each final segment actual POV SteamID.
- Apply both low/high 32-bit CS2 voice masks and start restricted modes silent.
- Abort fail-closed when a managed mask cannot be injected.

## Validation

- Backend recording/POV tests: 47 passed
- Frontend voice command tests: 5 passed
- git diff --check: passed
- Full local build is blocked by the existing node_modules missing the declared antd package.