### PR TITLE
perf(recording): batch keyboard overlay parsing

### DIFF
--- a/backend/app/obs_director.py
+++ b/backend/app/obs_director.py
@@ -3477,19 +3477,18 @@ class OBSDirector:
                     logger.warning("[RecordingV3] pre-build plan failed %s: %s", dto.request_id, _bp_e)
 
             if (_kb_any or _fx_any) and _plan_cache and not self._abort_requested():
-                from .parser.input_track import extract_input_track as _pre_extract_kb
+                from .parser.input_track import (
+                    extract_input_track as _pre_extract_kb,
+                    prepare_input_track_batch as _prepare_kb_batch,
+                )
                 from .parser.kill_track import extract_kill_track as _pre_extract_fx
-                _kb_shared_windows: dict[int, tuple[int, int]] = {}
+                _kb_prepared_by_demo: dict = {}
 
                 async def _extract_seg_pre(_seg, _demo_path):
                     if self._abort_requested():
                         _seg.metadata["kb_track"] = []
                         return
                     try:
-                        _shared_start, _shared_end = _kb_shared_windows.get(
-                            id(_seg),
-                            (_seg.start_tick, _seg.end_tick),
-                        )
                         _frames = await asyncio.to_thread(
                             _pre_extract_kb,
                             _demo_path,
@@ -3497,8 +3496,7 @@ class OBSDirector:
                             player_name=_seg.target_player_name,
                             start_tick=_seg.start_tick,
                             end_tick=_seg.end_tick,
-                            shared_start_tick=_shared_start,
-                            shared_end_tick=_shared_end,
+                            prepared=_kb_prepared_by_demo.get(_demo_path),
                         )
                         _seg.metadata["kb_track"] = _frames
                         logger.info(
@@ -3557,40 +3555,8 @@ class OBSDirector:
                             )
                             _kb_tasks.append((_extract_seg_fx, (_seg, _plan.demo_path, _ctx_tags)))
 
-                # 分批并行（每批 8 个），批次间检查 abort，保证中止响应及时
-                # Overlapping short segments share one tick parse.  Each
-                # result is still filtered to its own player and tick range.
-                for _demo_path, _segments in _kb_segments_by_demo.items():
-                    _ordered = sorted(_segments, key=lambda item: (item.start_tick, item.end_tick))
-                    _cluster: list = []
-                    _cluster_start = 0
-                    _cluster_end = 0
-
-                    def _flush_kb_cluster() -> None:
-                        for _cluster_seg in _cluster:
-                            _kb_shared_windows[id(_cluster_seg)] = (_cluster_start, _cluster_end)
-
-                    for _seg in _ordered:
-                        if not _cluster:
-                            _cluster = [_seg]
-                            _cluster_start, _cluster_end = _seg.start_tick, _seg.end_tick
-                            continue
-                        _candidate_end = max(_cluster_end, _seg.end_tick)
-                        _overlaps = _seg.start_tick <= _cluster_end + 64
-                        _within_dense_window = _candidate_end - _cluster_start + 1 <= 2000
-                        if _overlaps and _within_dense_window:
-                            _cluster.append(_seg)
-                            _cluster_end = _candidate_end
-                        else:
-                            _flush_kb_cluster()
-                            _cluster = [_seg]
-                            _cluster_start, _cluster_end = _seg.start_tick, _seg.end_tick
-                    if _cluster:
-                        _flush_kb_cluster()
-
-                # Four input-track tasks now share one cached tick parse.  A
-                # batch of four also keeps the following kill-event parse
-                # from competing with that first full demo read.
+                # Tick/event tables are parsed once per demo below.  Segment
+                # tasks only filter those shared tables and build their frames.
                 _BATCH = 4
                 _kb_total = len(_kb_tasks)
                 _kb_done = 0
@@ -3605,6 +3571,28 @@ class OBSDirector:
 
                 from .recording.kb_prebuild_state import start as _kbp_start, update as _kbp_update, finish as _kbp_finish, reset as _kbp_reset
                 _kbp_start(_kb_total)
+
+                for _demo_path, _segments in _kb_segments_by_demo.items():
+                    if self._abort_requested():
+                        break
+                    try:
+                        _kb_prepared_by_demo[_demo_path] = await asyncio.to_thread(
+                            _prepare_kb_batch,
+                            _demo_path,
+                            [(_seg.start_tick, _seg.end_tick) for _seg in _segments],
+                        )
+                        logger.info(
+                            "[kb_overlay] prepared shared demo tables: demo=%s segments=%d",
+                            _demo_path, len(_segments),
+                        )
+                    except Exception as _prepare_e:
+                        # Preserve recording correctness if an unsupported demo
+                        # cannot use the optimized batch path.
+                        logger.warning(
+                            "[kb_overlay] shared demo preparation failed; falling back to "
+                            "per-segment extraction: demo=%s error=%s",
+                            _demo_path, _prepare_e,
+                        )
 
                 for _batch_index, _batch in enumerate(_task_batches):
                     if self._abort_requested():

--- a/backend/app/parser/input_track.py
+++ b/backend/app/parser/input_track.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 import math
 import os
 import threading
@@ -58,6 +59,50 @@ _TICK_CACHE_MAX = 8
 _EVENT_CACHE_MAX = 8
 _tick_table_cache: dict[tuple, pd.DataFrame] = {}
 _event_table_cache: dict[tuple, pd.DataFrame] = {}
+
+_TICK_PROPS = (
+    PROP_BUTTONS,
+    PROP_USERCMD_BUTTONS,
+    PROP_X,
+    PROP_Y,
+    PROP_YAW,
+    PROP_WALK,
+    PROP_SCOPE,
+    PROP_DUCKING,
+    PROP_DESIRES_DUCK,
+    PROP_RELOAD,
+    PROP_FIRE,
+    PROP_RIGHTCLICK,
+    PROP_FORWARD,
+    PROP_MOVELEFT,
+    PROP_MOVERIGHT,
+    PROP_MOVEBACK,
+    PROP_WALK_BTN,
+    PROP_RELOAD_BTN,
+    "name",
+    "steamid",
+)
+_DENSE_PROPS = (
+    PROP_BUTTONS,
+    PROP_USERCMD_BUTTONS,
+    PROP_FIRE,
+    PROP_RIGHTCLICK,
+    PROP_SCOPE,
+    "name",
+    "steamid",
+)
+
+
+@dataclass(frozen=True)
+class PreparedInputTrackBatch:
+    """Demo-level parse tables shared by every keyboard-overlay segment."""
+
+    demo_key: tuple[str, int, int]
+    sample_table: pd.DataFrame
+    dense_table: pd.DataFrame
+    sample_ticks_by_window: dict[tuple[int, int], frozenset[int]]
+    dense_ticks_by_window: dict[tuple[int, int], frozenset[int]]
+    event_tables: dict[str, pd.DataFrame]
 
 
 def _demo_cache_key(demo_path: str) -> tuple[str, int, int]:
@@ -122,6 +167,124 @@ def _load_event_table(demo_path: str, event_name: str, *, rich_fire: bool = Fals
                 _event_table_cache.pop(next(iter(_event_table_cache)))
             _event_table_cache[key] = table
         return table
+
+
+def _window_tick_schedule(start_tick: int, end_tick: int) -> tuple[list[int], list[int]]:
+    start_i, end_i = int(start_tick), int(end_tick)
+    if end_i < start_i:
+        raise ValueError(f"Invalid input-track tick window: {start_i}-{end_i}")
+    total = end_i - start_i + 1
+    stride = max(1, (total + _MAX_TICKS - 1) // _MAX_TICKS)
+    sample_ticks = list(range(start_i, end_i + 1, stride))
+    if stride <= 1:
+        return sample_ticks, []
+    dense_stride = max(1, (total + _MAX_DENSE_TICKS - 1) // _MAX_DENSE_TICKS)
+    return sample_ticks, list(range(start_i, end_i + 1, dense_stride))
+
+
+def _parse_input_event_tables(demo_path: str) -> dict[str, pd.DataFrame]:
+    """Parse all keyboard-overlay events in one demo scan when supported."""
+    names = ("weapon_fire", "weapon_zoom")
+    parser = DemoParser(demo_path)
+    parsed = None
+    try:
+        parsed = parser.parse_events(
+            list(names),
+            player=["FIRE", "RIGHTCLICK", "buttons"],
+        )
+    except Exception:
+        try:
+            parsed = parser.parse_events(list(names))
+        except Exception:
+            parsed = None
+
+    if parsed is None:
+        return {
+            "weapon_fire": _load_event_table(demo_path, "weapon_fire", rich_fire=True),
+            "weapon_zoom": _load_event_table(demo_path, "weapon_zoom"),
+        }
+
+    out = {name: pd.DataFrame() for name in names}
+    for item in parsed:
+        if not isinstance(item, (list, tuple)) or len(item) != 2:
+            continue
+        event_name, table = item
+        if event_name in out:
+            out[event_name] = _to_df(table)
+    return out
+
+
+def prepare_input_track_batch(
+    demo_path: str,
+    windows: list[tuple[int, int]],
+) -> PreparedInputTrackBatch:
+    """Parse the union of all requested ticks once, preserving per-window density."""
+    sample_ticks_by_window: dict[tuple[int, int], frozenset[int]] = {}
+    dense_ticks_by_window: dict[tuple[int, int], frozenset[int]] = {}
+    all_sample_ticks: set[int] = set()
+    all_dense_ticks: set[int] = set()
+
+    for raw_start, raw_end in windows:
+        window = (int(raw_start), int(raw_end))
+        if window in sample_ticks_by_window:
+            continue
+        sample_ticks, dense_ticks = _window_tick_schedule(*window)
+        sample_set = frozenset(sample_ticks)
+        dense_set = frozenset(dense_ticks)
+        sample_ticks_by_window[window] = sample_set
+        dense_ticks_by_window[window] = dense_set
+        all_sample_ticks.update(sample_set)
+        all_dense_ticks.update(dense_set)
+
+    if not sample_ticks_by_window:
+        empty = pd.DataFrame()
+        return PreparedInputTrackBatch(
+            demo_key=_demo_cache_key(demo_path),
+            sample_table=empty,
+            dense_table=empty,
+            sample_ticks_by_window={},
+            dense_ticks_by_window={},
+            event_tables={},
+        )
+
+    parser = DemoParser(demo_path)
+    sample_table = _to_df(parser.parse_ticks(list(_TICK_PROPS), ticks=sorted(all_sample_ticks)))
+    sample_mask = _resolve_button_mask_col(sample_table)
+    dense_table = (
+        _to_df(parser.parse_ticks(list(_DENSE_PROPS), ticks=sorted(all_dense_ticks)))
+        if all_dense_ticks and sample_mask not in (None, PROP_USERCMD_BUTTONS)
+        else pd.DataFrame()
+    )
+    return PreparedInputTrackBatch(
+        demo_key=_demo_cache_key(demo_path),
+        sample_table=sample_table,
+        dense_table=dense_table,
+        sample_ticks_by_window=sample_ticks_by_window,
+        dense_ticks_by_window=dense_ticks_by_window,
+        event_tables=_parse_input_event_tables(demo_path),
+    )
+
+
+def _prepared_tick_table(
+    prepared: PreparedInputTrackBatch | None,
+    demo_path: str,
+    window: tuple[int, int],
+    *,
+    dense: bool = False,
+) -> pd.DataFrame | None:
+    if prepared is None or prepared.demo_key != _demo_cache_key(demo_path):
+        return None
+    ticks_by_window = (
+        prepared.dense_ticks_by_window if dense else prepared.sample_ticks_by_window
+    )
+    ticks = ticks_by_window.get(window)
+    if ticks is None:
+        return None
+    table = prepared.dense_table if dense else prepared.sample_table
+    if table.empty or "tick" not in table.columns:
+        return table
+    table_ticks = pd.to_numeric(table["tick"], errors="coerce")
+    return table.loc[table_ticks.isin(ticks)]
 
 
 def _resolve_col(df: pd.DataFrame, *candidates: str) -> str | None:
@@ -471,6 +634,7 @@ def extract_input_track(
     end_tick: int,
     shared_start_tick: int | None = None,
     shared_end_tick: int | None = None,
+    prepared: PreparedInputTrackBatch | None = None,
 ) -> list[dict]:
     """返回 [{tick, W,A,S,D,jump,crouch,walk,reload,fire,scope}, ...]（按 tick 升序）。
 
@@ -484,29 +648,10 @@ def extract_input_track(
     stride = max(1, (total + _MAX_TICKS - 1) // _MAX_TICKS)
     sample_ticks = list(range(parse_start_i, parse_end_i + 1, stride))
 
-    tick_props = [
-        PROP_BUTTONS,
-        PROP_USERCMD_BUTTONS,
-        PROP_X,
-        PROP_Y,
-        PROP_YAW,
-        PROP_WALK,
-        PROP_SCOPE,
-        PROP_DUCKING,
-        PROP_DESIRES_DUCK,
-        PROP_RELOAD,
-        PROP_FIRE,
-        PROP_RIGHTCLICK,
-        PROP_FORWARD,
-        PROP_MOVELEFT,
-        PROP_MOVERIGHT,
-        PROP_MOVEBACK,
-        PROP_WALK_BTN,
-        PROP_RELOAD_BTN,
-        "name",
-        "steamid",
-    ]
-    df = _load_tick_table(demo_path, tick_props, sample_ticks)
+    parse_window = (parse_start_i, parse_end_i)
+    df = _prepared_tick_table(prepared, demo_path, parse_window)
+    if df is None:
+        df = _load_tick_table(demo_path, list(_TICK_PROPS), sample_ticks)
     if df.empty:
         return []
     frame_ticks = pd.to_numeric(df["tick"], errors="coerce")
@@ -540,7 +685,13 @@ def extract_input_track(
     uses_usercmd_fallback = c_mask == PROP_USERCMD_BUTTONS
     mask_ints = _to_int_list(pdf[c_mask])
     n = len(mask_ints)
-    fire_events = _load_event_table(demo_path, "weapon_fire", rich_fire=True)
+    fire_events = (
+        prepared.event_tables.get("weapon_fire")
+        if prepared is not None and prepared.demo_key == _demo_cache_key(demo_path)
+        else None
+    )
+    if fire_events is None:
+        fire_events = _load_event_table(demo_path, "weapon_fire", rich_fire=True)
     if uses_usercmd_fallback:
         inferred = _infer_movement_from_motion(pdf)
         w_derived = inferred["W"]
@@ -591,16 +742,9 @@ def extract_input_track(
     if stride > 1 and not uses_usercmd_fallback:
         dense_stride = max(1, (total + _MAX_DENSE_TICKS - 1) // _MAX_DENSE_TICKS)
         dense_ticks = list(range(parse_start_i, parse_end_i + 1, dense_stride))
-        dense_props = [
-                PROP_BUTTONS,
-                PROP_USERCMD_BUTTONS,
-                PROP_FIRE,
-                PROP_RIGHTCLICK,
-                PROP_SCOPE,
-                "name",
-                "steamid",
-            ]
-        dense_df = _load_tick_table(demo_path, dense_props, dense_ticks)
+        dense_df = _prepared_tick_table(prepared, demo_path, parse_window, dense=True)
+        if dense_df is None:
+            dense_df = _load_tick_table(demo_path, list(_DENSE_PROPS), dense_ticks)
         if not dense_df.empty:
             dense_values = pd.to_numeric(dense_df["tick"], errors="coerce")
             dense_df = dense_df.loc[
@@ -640,8 +784,15 @@ def extract_input_track(
             start_tick=start_i,
             end_tick=end_i,
         )
+        zoom_events = (
+            prepared.event_tables.get("weapon_zoom")
+            if prepared is not None and prepared.demo_key == _demo_cache_key(demo_path)
+            else None
+        )
+        if zoom_events is None:
+            zoom_events = _load_event_table(demo_path, "weapon_zoom")
         zoom_ticks = _event_ticks_for_player(
-            _load_event_table(demo_path, "weapon_zoom"),
+            zoom_events,
             steamid=steamid,
             player_name=player_name,
             start_tick=start_i,

--- a/backend/app/recording/api.py
+++ b/backend/app/recording/api.py
@@ -442,7 +442,21 @@ async def execute_recording(dto: RecordingRequestDTO) -> dict:
     if _kb_overlay_req is None:
         _kb_overlay_req = load_config().kb_overlay_enabled
     if _kb_overlay_req:
-        from ..parser.input_track import extract_input_track as _extract_kb
+        from ..parser.input_track import (
+            extract_input_track as _extract_kb,
+            prepare_input_track_batch as _prepare_kb_batch,
+        )
+        try:
+            _kb_prepared = _prepare_kb_batch(
+                plan.demo_path,
+                [(_seg.start_tick, _seg.end_tick) for _seg in plan.segments],
+            )
+        except Exception as _kb_prepare_e:
+            logger.warning(
+                "kb_track shared preparation failed; using per-segment extraction: %s",
+                _kb_prepare_e,
+            )
+            _kb_prepared = None
         _kb_off_req = dto.options.kb_overlay_tick_offset  # None → executor falls back to global config
         for _seg in plan.segments:
             _seg.metadata["kb_tick_offset"] = _kb_off_req
@@ -453,6 +467,7 @@ async def execute_recording(dto: RecordingRequestDTO) -> dict:
                     player_name=_seg.target_player_name,
                     start_tick=_seg.start_tick,
                     end_tick=_seg.end_tick,
+                    prepared=_kb_prepared,
                 )
             except Exception as _kb_e:
                 logger.warning(

--- a/backend/tests/test_input_track.py
+++ b/backend/tests/test_input_track.py
@@ -234,3 +234,174 @@ def test_overlapping_segments_share_one_tick_and_event_parse(monkeypatch):
     assert [row["tick"] for row in p2_track] == [103, 104, 105]
     assert all(row["W"] and not row["A"] for row in p1_track)
     assert all(row["A"] and not row["W"] for row in p2_track)
+
+
+def test_prepared_batch_shares_distant_segments_without_losing_density(monkeypatch):
+    parser_constructs = 0
+    parse_tick_calls = 0
+    parse_events_calls = 0
+    parse_event_calls = 0
+
+    class FakeParser:
+        def __init__(self, _path):
+            nonlocal parser_constructs
+            parser_constructs += 1
+
+        def parse_ticks(self, _props, *, ticks):
+            nonlocal parse_tick_calls
+            parse_tick_calls += 1
+            rows = []
+            for tick in ticks:
+                rows.append({"tick": tick, "buttons": 1 << 3, "name": "p1", "steamid": "1"})
+                rows.append({"tick": tick, "buttons": 1 << 9, "name": "p2", "steamid": "2"})
+            return pd.DataFrame(rows)
+
+        def parse_events(self, event_names, **_kwargs):
+            nonlocal parse_events_calls
+            parse_events_calls += 1
+            return [
+                (
+                    event_name,
+                    pd.DataFrame(columns=["tick", "user_name", "user_steamid", "weapon"]),
+                )
+                for event_name in reversed(event_names)
+            ]
+
+        def parse_event(self, _event_name, **_kwargs):
+            nonlocal parse_event_calls
+            parse_event_calls += 1
+            raise AssertionError("prepared batch must not fall back to per-event parsing")
+
+    monkeypatch.setattr(input_track_module, "DemoParser", FakeParser)
+    windows = [(100, 102), (10_000, 10_002)]
+    prepared = input_track_module.prepare_input_track_batch("shared.dem", windows)
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        first = pool.submit(
+            input_track_module.extract_input_track,
+            "shared.dem",
+            player_name="p1",
+            steamid="1",
+            start_tick=100,
+            end_tick=102,
+            prepared=prepared,
+        )
+        second = pool.submit(
+            input_track_module.extract_input_track,
+            "shared.dem",
+            player_name="p2",
+            steamid="2",
+            start_tick=10_000,
+            end_tick=10_002,
+            prepared=prepared,
+        )
+        p1_track = first.result()
+        p2_track = second.result()
+
+    assert parser_constructs == 2
+    assert parse_tick_calls == 1
+    assert parse_events_calls == 1
+    assert parse_event_calls == 0
+    assert [row["tick"] for row in p1_track] == [100, 101, 102]
+    assert [row["tick"] for row in p2_track] == [10_000, 10_001, 10_002]
+
+
+def test_prepared_batch_reuses_dense_short_press_table(monkeypatch):
+    parse_tick_calls = 0
+
+    class FakeParser:
+        def __init__(self, _path):
+            pass
+
+        def parse_ticks(self, _props, *, ticks):
+            nonlocal parse_tick_calls
+            parse_tick_calls += 1
+            return pd.DataFrame({
+                "tick": ticks,
+                "buttons": [1 << 3 for _ in ticks],
+                "name": ["p1" for _ in ticks],
+                "steamid": ["1" for _ in ticks],
+            })
+
+        def parse_events(self, event_names, **_kwargs):
+            return [
+                (
+                    event_name,
+                    pd.DataFrame(columns=["tick", "user_name", "user_steamid", "weapon"]),
+                )
+                for event_name in event_names
+            ]
+
+    monkeypatch.setattr(input_track_module, "DemoParser", FakeParser)
+    prepared = input_track_module.prepare_input_track_batch(
+        "long.dem",
+        [(100, 3_100), (10_000, 13_000)],
+    )
+    first = input_track_module.extract_input_track(
+        "long.dem",
+        player_name="p1",
+        steamid="1",
+        start_tick=100,
+        end_tick=3_100,
+        prepared=prepared,
+    )
+    second = input_track_module.extract_input_track(
+        "long.dem",
+        player_name="p1",
+        steamid="1",
+        start_tick=10_000,
+        end_tick=13_000,
+        prepared=prepared,
+    )
+
+    # One union parse for regular frames and one for dense short-press frames,
+    # regardless of the number or distance of the segments.
+    assert parse_tick_calls == 2
+    assert len(first) == 1_501
+    assert len(second) == 1_501
+    assert first[0]["tick"] == 100 and first[-1]["tick"] == 3_100
+    assert second[0]["tick"] == 10_000 and second[-1]["tick"] == 13_000
+
+
+def test_prepared_batch_skips_dense_parse_for_usercmd_fallback(monkeypatch):
+    parse_tick_calls = 0
+
+    class FakeParser:
+        def __init__(self, _path):
+            pass
+
+        def parse_ticks(self, _props, *, ticks):
+            nonlocal parse_tick_calls
+            parse_tick_calls += 1
+            return pd.DataFrame({
+                "tick": ticks,
+                "usercmd_buttonstate_1": [0 for _ in ticks],
+                "name": ["p1" for _ in ticks],
+                "steamid": ["1" for _ in ticks],
+            })
+
+        def parse_events(self, event_names, **_kwargs):
+            return [
+                (
+                    event_name,
+                    pd.DataFrame(columns=["tick", "user_name", "user_steamid", "weapon"]),
+                )
+                for event_name in event_names
+            ]
+
+    monkeypatch.setattr(input_track_module, "DemoParser", FakeParser)
+    prepared = input_track_module.prepare_input_track_batch(
+        "new-format.dem",
+        [(100, 3_100), (10_000, 13_000)],
+    )
+    track = input_track_module.extract_input_track(
+        "new-format.dem",
+        player_name="p1",
+        steamid="1",
+        start_tick=100,
+        end_tick=3_100,
+        prepared=prepared,
+    )
+
+    assert parse_tick_calls == 1
+    assert len(track) == 1_501


### PR DESCRIPTION
## 改动内容

- 将同一份 Demo 的虚拟键盘 tick 数据改为按所有录制片段的 tick 范围合并解析一次，再按片段切片复用。
- 合并提取 `weapon_fire` 和 `weapon_zoom` 事件，同时保持每个片段原有的采样密度。
- 录制队列和单次录制接口统一使用批量预解析结果；批量路径失败时仍会安全回退到逐片段提取。
- 增加分散片段、旧式 dense 短按数据和新版 usercmd Demo 的测试覆盖。

## 问题根因

Phase 0 原先会针对每个录制片段分别调用一次 `extract_input_track`。旧缓存只能复用 tick 列表完全相同或被聚合到同一小窗口的片段；相距较远的片段仍会反复通过 `DemoParser.parse_ticks` 扫描同一份 Demo，并分别解析事件表。

## 性能影响

使用真实 Demo，每份选取 6 个基于实际击杀事件的分散片段进行测试；新旧实现生成的虚拟键盘轨道逐条完全一致。

| Demo 大小 | 修改前 | 修改后 | 加速比 |
| --- | ---: | ---: | ---: |
| 193.5 MB | 6.452 秒 | 1.255 秒 | 5.14 倍 |
| 294.6 MB | 8.296 秒 | 1.589 秒 | 5.22 倍 |
| 543.4 MB | 16.410 秒 | 4.129 秒 | 3.97 倍 |

以 6 个片段为例，解析工作量从 6 次 `parse_ticks` 加 2 次 `parse_event`，下降为 1 次 `parse_ticks` 加 1 次批量 `parse_events`。使用发布包 lean Python runtime 的长片段测试由 3.238 秒降至 1.139 秒，输出保持一致。

## 验证

- `.venv\Scripts\python.exe -m pytest backend\tests -q`：424 项通过
- `git diff --check`：通过
